### PR TITLE
rename Tan::adj -> smallAdj

### DIFF
--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -90,7 +90,7 @@ __attribute__(( noinline, cold, noreturn )) raise(Args&&... args)
   using Base::hat;                \
   using Base::rjac;               \
   using Base::ljac;               \
-  using Base::adj;
+  using Base::smallAdj;
 
 #define MANIF_INHERIT_TANGENT_OPERATOR \
   using Base::operator +;              \

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -39,7 +39,7 @@ public:
   Jacobian rjac() const;
   Jacobian ljac() const;
 
-  Jacobian adj() const;
+  Jacobian smallAdj() const;
 
   /// SE2Tangent specific API
 
@@ -194,16 +194,16 @@ SE2TangentBase<_Derived>::ljac() const
 
 template <typename _Derived>
 typename SE2TangentBase<_Derived>::Jacobian
-SE2TangentBase<_Derived>::adj() const
+SE2TangentBase<_Derived>::smallAdj() const
 {
-  Jacobian adj = Jacobian::Zero();
+  Jacobian smallAdj = Jacobian::Zero();
 
-  adj(0,1) = -angle();
-  adj(1,0) =  angle();
-  adj(0,2) =  y();
-  adj(1,2) = -x();
+  smallAdj(0,1) = -angle();
+  smallAdj(1,0) =  angle();
+  smallAdj(0,2) =  y();
+  smallAdj(1,2) = -x();
 
-  return adj;
+  return smallAdj;
 }
 
 /// SE2Tangent specific API

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -48,7 +48,7 @@ public:
   Jacobian rjac() const;
   Jacobian ljac() const;
 
-  Jacobian adj() const;
+  Jacobian smallAdj() const;
 
   /// SE3Tangent specific API
 
@@ -236,16 +236,16 @@ SE3TangentBase<_Derived>::ljac() const
 
 template <typename _Derived>
 typename SE3TangentBase<_Derived>::Jacobian
-SE3TangentBase<_Derived>::adj() const
+SE3TangentBase<_Derived>::smallAdj() const
 {
-  Jacobian adj = Jacobian::Zero();
-  adj.template topLeftCorner<3,3>() = asSO3().hat();
-  adj.template bottomRightCorner<3,3>() =
-      adj.template topLeftCorner<3,3>();
+  Jacobian smallAdj = Jacobian::Zero();
+  smallAdj.template topLeftCorner<3,3>() = asSO3().hat();
+  smallAdj.template bottomRightCorner<3,3>() =
+      smallAdj.template topLeftCorner<3,3>();
 
-  adj.template bottomLeftCorner<3,3>() = skew(v());
+  smallAdj.template bottomLeftCorner<3,3>() = skew(v());
 
-  return adj;
+  return smallAdj;
 }
 
 /// SE3Tangent specific API

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -43,7 +43,7 @@ public:
   Jacobian rjacinv() const;
   Jacobian ljacinv() const;
 
-  Jacobian adj() const;
+  Jacobian smallAdj() const;
 
   /// SO2Tangent specific API
 
@@ -108,10 +108,10 @@ SO2TangentBase<_Derived>::ljacinv() const
 
 template <typename _Derived>
 typename SO2TangentBase<_Derived>::Jacobian
-SO2TangentBase<_Derived>::adj() const
+SO2TangentBase<_Derived>::smallAdj() const
 {
-  static const Jacobian adj = Jacobian::Constant(Scalar(1));
-  return adj;
+  static const Jacobian smallAdj = Jacobian::Constant(Scalar(1));
+  return smallAdj;
 }
 
 /// SO2Tangent specific API

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -39,7 +39,7 @@ public:
   Jacobian rjac() const;
   Jacobian ljac() const;
 
-  Jacobian adj() const;
+  Jacobian smallAdj() const;
 
   /// SO3Tangent specific API
 
@@ -120,7 +120,7 @@ SO3TangentBase<_Derived>::ljac() const
 
 template <typename _Derived>
 typename SO3TangentBase<_Derived>::Jacobian
-SO3TangentBase<_Derived>::adj() const
+SO3TangentBase<_Derived>::smallAdj() const
 {
   return hat();
 }

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -100,7 +100,7 @@ public:
     not internal::has_ljacinv<U>::value,
     typename TangentBase<U>::Jacobian>::type ljacinv() const;
 
-  Jacobian adj() const;
+  Jacobian smallAdj() const;
 
   template <typename _DerivedOther>
   bool isApprox(const TangentBase<_DerivedOther>& t, const Scalar eps) const;
@@ -323,10 +323,9 @@ TangentBase<_Derived>::ljacinv() const
 
 template <class _Derived>
 typename TangentBase<_Derived>::Jacobian
-TangentBase<_Derived>::adj() const
+TangentBase<_Derived>::smallAdj() const
 {
-  //  return derived().ljac()*derived().rjac().inverse();
-  return derived().adj();
+  return derived().smallAdj();
 }
 
 template <typename _Derived>


### PR DESCRIPTION
Rename `'Tangent'::adj` to `'Tangent'::smallAdj`.