### PR TITLE
Fix random

### DIFF
--- a/include/manif/impl/random.h
+++ b/include/manif/impl/random.h
@@ -1,0 +1,39 @@
+#ifndef _MANIF_MANIF_IMPL_RANDOM_H_
+#define _MANIF_MANIF_IMPL_RANDOM_H_
+
+namespace manif {
+namespace internal {
+
+template <typename Derived>
+struct RandomEvaluatorImpl
+{
+  template <typename EigenDerived>
+  static void run(Eigen::MatrixBase<EigenDerived>&)
+  {
+    /// @todo print actual Derived type
+    static_assert(constexpr_false<Derived>(),
+                  "RandomEvaluator not overloaded for Derived type!");
+  }
+};
+
+template <typename Derived>
+struct RandomEvaluator : RandomEvaluatorImpl<Derived>
+{
+  using Base = RandomEvaluatorImpl<Derived>;
+
+  RandomEvaluator(Derived& xptr) : xptr_(xptr) {}
+
+  void run()
+  {
+    Base::run(xptr_.coeffs());
+  }
+
+protected:
+
+  Derived& xptr_;
+};
+
+} /* namespace internal */
+} /* namespace manif */
+
+#endif /* _MANIF_MANIF_IMPL_RANDOM_H_ */

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -335,6 +335,17 @@ struct WEvaluator<SE2TangentBase<Derived>>
   }
 };
 
+template <typename Derived>
+struct RandomEvaluatorImpl<SE2TangentBase<Derived>>
+{
+  template <typename EigenDerived>
+  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  {
+    // in [-1,1] /   in [-PI,PI]
+    m.setRandom().coeffRef(2) *= M_PI;
+  }
+};
+
 } /* namespace internal */
 } /* namespace manif */
 

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -341,8 +341,8 @@ struct RandomEvaluatorImpl<SE2TangentBase<Derived>>
   template <typename EigenDerived>
   static void run(Eigen::MatrixBase<EigenDerived>& m)
   {
-    // in [-1,1] /   in [-PI,PI]
-    m.setRandom().coeffRef(2) *= M_PI;
+    m.setRandom();         // in [-1,1]
+    m.coeffRef(2) *= M_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -386,6 +386,17 @@ struct GeneratorEvaluator<SE3TangentBase<Derived>>
   }
 };
 
+template <typename Derived>
+struct RandomEvaluatorImpl<SE3TangentBase<Derived>>
+{
+  template <typename EigenDerived>
+  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  {
+    // in [-1,1] /   in [-PI,PI]
+    m.setRandom().template tail<3>() *= M_PI;
+  }
+};
+
 } /* namespace internal */
 } /* namespace manif */
 

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -392,8 +392,8 @@ struct RandomEvaluatorImpl<SE3TangentBase<Derived>>
   template <typename EigenDerived>
   static void run(Eigen::MatrixBase<EigenDerived>& m)
   {
-    // in [-1,1] /   in [-PI,PI]
-    m.setRandom().template tail<3>() *= M_PI;
+    m.setRandom();                // in [-1,1]
+    m.template tail<3>() *= M_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -195,6 +195,17 @@ struct GeneratorEvaluator<SO2TangentBase<Derived>>
   }
 };
 
+template <typename Derived>
+struct RandomEvaluatorImpl<SO2TangentBase<Derived>>
+{
+  template <typename EigenDerived>
+  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  {
+    // in [-1,1]  /  in [-PI,PI]
+    m.setRandom() *= M_PI;
+  }
+};
+
 } /* namespace internal */
 } /* namespace manif */
 

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -280,6 +280,17 @@ struct GeneratorEvaluator<SO3TangentBase<Derived>>
   }
 };
 
+template <typename Derived>
+struct RandomEvaluatorImpl<SO3TangentBase<Derived>>
+{
+  template <typename EigenDerived>
+  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  {
+    // in [-1,1]  / in [-PI,PI]
+    m.setRandom() *= M_PI;
+  }
+};
+
 } /* namespace internal */
 } /* namespace manif */
 

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -4,6 +4,7 @@
 #include "manif/impl/macro.h"
 #include "manif/impl/traits.h"
 #include "manif/impl/generator.h"
+#include "manif/impl/random.h"
 #include "manif/impl/eigen.h"
 
 #include "manif/constants.h"
@@ -373,7 +374,10 @@ _Derived& TangentBase<_Derived>::setZero()
 template <class _Derived>
 _Derived& TangentBase<_Derived>::setRandom()
 {
-  coeffs().setRandom();
+  internal::RandomEvaluator<
+      typename internal::traits<_Derived>::Base>(
+        derived()).run();
+
   return derived();
 }
 

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -310,6 +310,8 @@ public:
 
   void evalAvgBiInvariant()
   {
+    // Note : average works over points that are 'close'.
+
     EXPECT_THROW(average_biinvariant(std::vector<LieGroup>{}),
                  std::runtime_error);
 
@@ -317,11 +319,18 @@ public:
     EXPECT_MANIF_NEAR(dummy,
      average_biinvariant(std::vector<LieGroup>{dummy}), tol_);
 
+    const LieGroup centroid = LieGroup::Random();
+
     std::vector<LieGroup> mans;
 
+    // Generate N points arround the centroid
     const int N = 15;
     for (int i=0; i<N; ++i)
-      mans.emplace_back(LieGroup::Random());
+    {
+      mans.push_back(
+            centroid + (Tangent::Random()*0.25)
+            );
+    }
 
     const auto avg = average_biinvariant(mans);
 


### PR DESCRIPTION
Fix `random` which was spanning range `[-1, 1]` for all `Tangent` coefficients.
It now spans range `[-pi, pi]` where necessary.

The current implementation requires a specialization for each intermediate `Tangent` derived types.