### PR TITLE
fix #68 - quaternion randomization

### DIFF
--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -369,7 +369,10 @@ template <typename _Derived>
 _Derived&
 LieGroupBase<_Derived>::setRandom()
 {
-  coeffs_nonconst() = Tangent::Random().exp().coeffs();
+  internal::RandomEvaluator<
+      typename internal::traits<_Derived>::Base>(
+        derived()).run();
+
   return derived();
 }
 

--- a/include/manif/impl/random.h
+++ b/include/manif/impl/random.h
@@ -7,8 +7,8 @@ namespace internal {
 template <typename Derived>
 struct RandomEvaluatorImpl
 {
-  template <typename EigenDerived>
-  static void run(Eigen::MatrixBase<EigenDerived>&)
+  template <typename T>
+  static void run(T&)
   {
     /// @todo print actual Derived type
     static_assert(constexpr_false<Derived>(),
@@ -25,7 +25,7 @@ struct RandomEvaluator : RandomEvaluatorImpl<Derived>
 
   void run()
   {
-    Base::run(xptr_.coeffs());
+    Base::run(xptr_);
   }
 
 protected:

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -353,11 +353,10 @@ struct WEvaluator<SE2TangentBase<Derived>>
 template <typename Derived>
 struct RandomEvaluatorImpl<SE2TangentBase<Derived>>
 {
-  template <typename EigenDerived>
-  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  static void run(SE2TangentBase<Derived>& m)
   {
-    m.setRandom();         // in [-1,1]
-    m.coeffRef(2) *= M_PI; // in [-PI,PI]
+    m.coeffs().setRandom();         // in [-1,1]
+    m.coeffs().coeffRef(2) *= M_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -346,6 +346,20 @@ SE2Base<_Derived>::y() const
   return coeffs().y();
 }
 
+namespace internal {
+
+template <typename Derived>
+struct RandomEvaluatorImpl<SE2Base<Derived>>
+{
+  template <typename T>
+  static void run(T& m)
+  {
+    using Tangent = typename LieGroupBase<Derived>::Tangent;
+    m = Tangent::Random().exp();
+  }
+};
+
+} /* namespace internal */
 } /* namespace manif */
 
 #endif /* _MANIF_MANIF_SE2_BASE_H_ */

--- a/include/manif/impl/se2/SE2_map.h
+++ b/include/manif/impl/se2/SE2_map.h
@@ -12,8 +12,9 @@ struct traits< Eigen::Map<SE2<_Scalar>,0> >
     : public traits<SE2<_Scalar>>
 {
   using typename traits<SE2<_Scalar>>::Scalar;
-  using traits<SE2<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<SE2<Scalar>>::RepSize;
+  using Base = SE2Base<Eigen::Map<SE2<Scalar>, 0>>;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 //! @brief traits specialization for Eigen Map const
@@ -22,8 +23,9 @@ struct traits< Eigen::Map<const SE2<_Scalar>,0> >
     : public traits<const SE2<_Scalar>>
 {
   using typename traits<const SE2<_Scalar>>::Scalar;
-  using traits<const SE2<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<const SE2<Scalar>>::RepSize;
+  using Base = SE2Base<Eigen::Map<const SE2<Scalar>, 0>>;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -431,11 +431,10 @@ struct GeneratorEvaluator<SE3TangentBase<Derived>>
 template <typename Derived>
 struct RandomEvaluatorImpl<SE3TangentBase<Derived>>
 {
-  template <typename EigenDerived>
-  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  static void run(SE3TangentBase<Derived>& m)
   {
-    m.setRandom();                // in [-1,1]
-    m.template tail<3>() *= M_PI; // in [-PI,PI]
+    m.coeffs().setRandom();                // in [-1,1]
+    m.coeffs().template tail<3>() *= M_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -339,6 +339,21 @@ SE3Base<_Derived>::z() const
   return coeffs().z();
 }
 
+namespace internal {
+
+template <typename Derived>
+struct RandomEvaluatorImpl<SE3Base<Derived>>
+{
+  template <typename T>
+  static void run(T& m)
+  {
+    using Translation = typename SE3Base<Derived>::Translation;
+    using Quaternion  = typename SE3Base<Derived>::QuaternionDataType;
+    m = Derived(Translation::Random(), Quaternion::UnitRandom());
+  }
+};
+
+} /* namespace internal */
 } /* namespace manif */
 
 #endif /* _MANIF_MANIF_SE3_BASE_H_ */

--- a/include/manif/impl/se3/SE3_map.h
+++ b/include/manif/impl/se3/SE3_map.h
@@ -12,8 +12,9 @@ struct traits< Eigen::Map<SE3<_Scalar>,0> >
     : public traits<SE3<_Scalar>>
 {
   using typename traits<SE3<_Scalar>>::Scalar;
-  using traits<SE3<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<SE3<Scalar>>::RepSize;
+  using Base = SE3Base<Eigen::Map<SE3<Scalar>, 0>>;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 //! @brief traits specialization for Eigen Map const
@@ -22,8 +23,9 @@ struct traits< Eigen::Map<const SE3<_Scalar>,0> >
     : public traits<const SE3<_Scalar>>
 {
   using typename traits<const SE3<_Scalar>>::Scalar;
-  using traits<const SE3<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<const SE3<Scalar>>::RepSize;
+  using Base = SE3Base<Eigen::Map<const SE3<Scalar>, 0>>;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -213,11 +213,10 @@ struct GeneratorEvaluator<SO2TangentBase<Derived>>
 template <typename Derived>
 struct RandomEvaluatorImpl<SO2TangentBase<Derived>>
 {
-  template <typename EigenDerived>
-  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  static void run(SO2TangentBase<Derived>& m)
   {
     // in [-1,1]  /  in [-PI,PI]
-    m.setRandom() *= M_PI;
+    m.coeffs().setRandom() *= M_PI;
   }
 };
 

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -285,6 +285,20 @@ SO2Base<_Derived>::angle() const
 //  return coeffs.y();
 //}
 
+namespace internal {
+
+template <typename Derived>
+struct RandomEvaluatorImpl<SO2Base<Derived>>
+{
+  template <typename T>
+  static void run(T& m)
+  {
+    using Tangent = typename LieGroupBase<Derived>::Tangent;
+    m = Tangent::Random().exp();
+  }
+};
+
+} /* namespace internal */
 } /* namespace manif */
 
 #endif /* _MANIF_MANIF_SO2_BASE_H_ */

--- a/include/manif/impl/so2/SO2_map.h
+++ b/include/manif/impl/so2/SO2_map.h
@@ -12,8 +12,9 @@ struct traits< Eigen::Map<SO2<_Scalar>,0> >
     : public traits<SO2<_Scalar>>
 {
   using typename traits<SO2<_Scalar>>::Scalar;
-  using traits<SO2<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<SO2<Scalar>>::RepSize;
+  using Base = SO2Base<Eigen::Map<SO2<Scalar>, 0>>;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 //! @brief traits specialization for Eigen Map const
@@ -22,8 +23,9 @@ struct traits< Eigen::Map<const SO2<_Scalar>,0> >
     : public traits<const SO2<_Scalar>>
 {
   using typename traits<const SO2<_Scalar>>::Scalar;
-  using traits<const SO2<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<const SO2<Scalar>>::RepSize;
+  using Base = SO2Base<Eigen::Map<const SO2<Scalar>, 0>>;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -298,11 +298,10 @@ struct GeneratorEvaluator<SO3TangentBase<Derived>>
 template <typename Derived>
 struct RandomEvaluatorImpl<SO3TangentBase<Derived>>
 {
-  template <typename EigenDerived>
-  static void run(Eigen::MatrixBase<EigenDerived>& m)
+  static void run(SO3TangentBase<Derived>& m)
   {
     // in [-1,1]  / in [-PI,PI]
-    m.setRandom() *= M_PI;
+    m.coeffs().setRandom() *= M_PI;
   }
 };
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -337,6 +337,20 @@ void SO3Base<_Derived>::normalize()
   coeffs().normalize();
 }
 
+namespace internal {
+
+template <typename Derived>
+struct RandomEvaluatorImpl<SO3Base<Derived>>
+{
+  template <typename T>
+  static void run(T& m)
+  {
+    using Quaternion = typename SO3Base<Derived>::QuaternionDataType;
+    m = Derived(Quaternion::UnitRandom());
+  }
+};
+
+} /* namespace internal */
 } /* namespace manif */
 
 #endif /* _MANIF_MANIF_SO3_BASE_H_ */

--- a/include/manif/impl/so3/SO3_map.h
+++ b/include/manif/impl/so3/SO3_map.h
@@ -12,8 +12,9 @@ struct traits< Eigen::Map<SO3<_Scalar>,0> >
     : public traits<SO3<_Scalar>>
 {
   using typename traits<SO3<_Scalar>>::Scalar;
-  using traits<SO3<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<SO3<Scalar>>::RepSize;
+  using Base = SO3Base<Eigen::Map<SO3<Scalar>, 0>>;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 //! @brief traits specialization for Eigen Map const
@@ -22,8 +23,9 @@ struct traits< Eigen::Map<const SO3<_Scalar>,0> >
     : public traits<const SO3<_Scalar>>
 {
   using typename traits<const SO3<_Scalar>>::Scalar;
-  using traits<const SO3<_Scalar>>::RepSize;
-  using DataType = ::Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+  using traits<const SO3<Scalar>>::RepSize;
+  using Base = SO3Base<Eigen::Map<const SO3<Scalar>, 0>>;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
 };
 
 } /* namespace internal */


### PR DESCRIPTION
Fix issue #68 by using `Eigen::Quaternion<Scalar>::UnitRandom()` in the randomization of SO3 and SE3.