### PR TITLE
Fix const SO3 normalize()

### DIFF
--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -62,6 +62,7 @@ public:
   MANIF_COMPLETE_GROUP_TYPEDEF
   MANIF_INHERIT_GROUP_API
 
+  using Base::normalize;
   using Base::quat;
 
   SO3()  = default;
@@ -145,6 +146,7 @@ SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
   : data_(data)
 {
   //
+  normalize();
 }
 
 template <typename _Scalar>
@@ -160,6 +162,7 @@ SO3<_Scalar>::SO3(const Scalar x, const Scalar y,
   : data_(x, y, z, w)
 {
   //
+  normalize();
 }
 
 template <typename _Scalar>

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -4,6 +4,7 @@
 #include "manif/impl/so3/SO3_properties.h"
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/utils.h"
+#include <Eigen/Geometry>
 
 namespace manif {
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -332,7 +332,7 @@ SO3Base<_Derived>::quat() const
 template <typename _Derived>
 void SO3Base<_Derived>::normalize()
 {
-  coeffs().normalize();
+  coeffs_nonconst().normalize();
 }
 
 namespace internal {


### PR DESCRIPTION
1. const coeffs() cannot be normalized [code](https://github.com/artivis/manif/blob/devel/include/manif/impl/so3/SO3_base.h#L335)

2. SO3 constructor should do the normalization (?)  **OR** make normalize() a public function.

3. #include <Eigen/Geometry> should be added to support Eigen::Quaternion.