### PR TITLE
Fix/eigen version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - cd build
 
   # Update / Install Eigen
-  - wget http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz && tar xzf 3.3.4.tar.gz && sudo cp -Rp eigen-eigen-5a0156e40feb /usr/local/include/eigen3;
+  - wget http://bitbucket.org/eigen/eigen/get/3.3-beta1.tar.gz && tar xzf 3.3-beta1.tar.gz && sudo cp -Rp eigen-eigen-ce5a455b34c0 /usr/local/include/eigen3;
 
   # #
   # # Update / Install CMake

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -345,9 +345,29 @@ struct RandomEvaluatorImpl<SE3Base<Derived>>
   template <typename T>
   static void run(T& m)
   {
+    // @note:
+    // Quaternion::UnitRandom is not available in Eigen 3.3-beta1
+    // which is the default version in Ubuntu 16.04
+    // So we copy its implementation here.
+
+    using std::sqrt;
+    using std::sin;
+    using std::cos;
+
+    using Scalar      = typename SE3Base<Derived>::Scalar;
     using Translation = typename SE3Base<Derived>::Translation;
     using Quaternion  = typename SE3Base<Derived>::QuaternionDataType;
-    m = Derived(Translation::Random(), Quaternion::UnitRandom());
+
+    const Scalar u1 = Eigen::internal::random<Scalar>(0, 1),
+                 u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI),
+                 u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
+    const Scalar a = sqrt(1. - u1),
+                 b = sqrt(u1);
+
+    m = Derived(Translation::Random(),
+                Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
+
+    //m = Derived(Translation::Random(), Quaternion::UnitRandom());
   }
 };
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -344,8 +344,28 @@ struct RandomEvaluatorImpl<SO3Base<Derived>>
   template <typename T>
   static void run(T& m)
   {
+
+    // @note:
+    // Quaternion::UnitRandom is not available in Eigen 3.3-beta1
+    // which is the default version in Ubuntu 16.04
+    // So we copy its implementation here.
+
+    using std::sqrt;
+    using std::sin;
+    using std::cos;
+
+    using Scalar = typename SO3Base<Derived>::Scalar;
     using Quaternion = typename SO3Base<Derived>::QuaternionDataType;
-    m = Derived(Quaternion::UnitRandom());
+
+    const Scalar u1 = Eigen::internal::random<Scalar>(0, 1),
+                 u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI),
+                 u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
+    const Scalar a = sqrt(1. - u1),
+                 b = sqrt(u1);
+    m = Derived(Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
+
+
+    // m = Derived(Quaternion::UnitRandom());
   }
 };
 


### PR DESCRIPTION
`Eigen::Quaterniond::UnitRandom()` is not available to Eigen 3.3-beta1 which seems to be the default Eigen version of Ubuntu 16.04.
- `UnitRandom` function implementation is copied directly in `manif` to improve compatibility
- Travis CI uses now Eigen 3.3-beta1