### PR TITLE
Add constructor from eigen::isometry in SE3

### DIFF
--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -120,7 +120,7 @@ public:
    * @brief Constructor from Eigen::Isometry3d
    * @param[in] h an isometry object from Eigen
    */
-  SE3(const Eigen::Isometry3d& h);
+  SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h);
 
   // LieGroup common API
 
@@ -199,7 +199,7 @@ SE3<_Scalar>::SE3(const Translation& t,
 }
 
 template <typename _Scalar>
-SE3<_Scalar>::SE3(const Eigen::Isometry3d& h)
+SE3<_Scalar>::SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h)
   : SE3(h.translation(), Eigen::Quaternion<_Scalar>(h.rotation()))
 {
   //

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -117,8 +117,11 @@ public:
       const SO3<Scalar>& SO3);
 
   /**
-   * @brief Constructor from Eigen::Isometry3d
+   * @brief Constructor from a 3D Eigen::Isometry<Scalar>
    * @param[in] h an isometry object from Eigen
+   *
+   * Isometry is a typedef from Eigen::Transform, in which the linear part is assumed a rotation matrix.
+   * This is used to speed up certain methods of Transform, especially inverse().
    */
   SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h);
 

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -4,6 +4,7 @@
 #include "manif/impl/se3/SE3_base.h"
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 
 namespace manif {
 
@@ -115,6 +116,12 @@ public:
   SE3(const Translation& t,
       const SO3<Scalar>& SO3);
 
+  /**
+   * @brief Constructor from Eigen::Isometry3d
+   * @param[in] h an isometry object from Eigen
+   */
+  SE3(const Eigen::Isometry3d& h);
+
   // LieGroup common API
 
   const DataType& coeffs() const;
@@ -190,6 +197,14 @@ SE3<_Scalar>::SE3(const Translation& t,
 {
   //
 }
+
+template <typename _Scalar>
+SE3<_Scalar>::SE3(const Eigen::Isometry3d& h)
+  : SE3(h.translation(), Eigen::Quaternion<_Scalar>(h.rotation()))
+{
+  //
+}
+
 
 template <typename _Scalar>
 typename SE3<_Scalar>::DataType&

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -4,7 +4,6 @@
 #include "manif/impl/se3/SE3_base.h"
 
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 
 namespace manif {
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -5,6 +5,8 @@
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/so3/SO3_map.h"
 
+#include <Eigen/Geometry>
+
 namespace manif {
 
 //
@@ -34,6 +36,7 @@ public:
   using Rotation       = typename internal::traits<_Derived>::Rotation;
   using Translation    = typename internal::traits<_Derived>::Translation;
   using Transformation = typename internal::traits<_Derived>::Transformation;
+  using Isometry       = Eigen::Transform<Scalar, 3, Eigen::Isometry>;
 
   using QuaternionDataType = Eigen::Quaternion<Scalar>;
 
@@ -107,6 +110,13 @@ public:
   Transformation transform() const;
 
   /**
+   * Get the isometry object (Eigen 3D isometry).
+   * @note T = | R t |
+   *           | 0 1 |
+   */
+  Isometry isometry() const;
+
+  /**
    * @brief Get the rotational part of this as a rotation matrix.
    */
   Rotation rotation() const;
@@ -164,6 +174,16 @@ SE3Base<_Derived>::transform() const
   Transformation T = Transformation::Identity();
   T.template topLeftCorner<3,3>()  = rotation();
   T.template topRightCorner<3,1>() = translation();
+  return T;
+}
+
+template <typename _Derived>
+typename SE3Base<_Derived>::Isometry
+SE3Base<_Derived>::isometry() const
+{
+  Isometry T = Isometry::Identity();
+  T.matrix().template topLeftCorner<3,3>()  = rotation();
+  T.matrix().template topRightCorner<3,1>() = translation();
   return T;
 }
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -181,9 +181,8 @@ template <typename _Derived>
 typename SE3Base<_Derived>::Isometry
 SE3Base<_Derived>::isometry() const
 {
-  Isometry T = Isometry::Identity();
-  T.matrix().template topLeftCorner<3,3>()  = rotation();
-  T.matrix().template topRightCorner<3,1>() = translation();
+  Isometry T;
+  T.matrix() = transform();
   return T;
 }
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -181,9 +181,7 @@ template <typename _Derived>
 typename SE3Base<_Derived>::Isometry
 SE3Base<_Derived>::isometry() const
 {
-  Isometry T;
-  T.matrix() = transform();
-  return T;
+  return Isometry(transform());
 }
 
 template <typename _Derived>

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -271,6 +271,52 @@ TEST(TEST_SE3, TEST_SE3_ACT)
   EXPECT_NEAR( 0, transformed_point.z(), 1e-15);
 }
 
+TEST(TEST_SE3, TEST_SE3_TRANSFORM)
+{
+  Eigen::Isometry3d h = Eigen::Translation3d(1,2,3) * Eigen::Quaterniond::Identity();
+
+  SE3d se3(h);
+
+  Eigen::Matrix4d se3h = se3.transform();
+
+  EXPECT_DOUBLE_EQ(1, se3h(0,0));
+  EXPECT_DOUBLE_EQ(0, se3h(0,1));
+  EXPECT_DOUBLE_EQ(0, se3h(0,2));
+  EXPECT_DOUBLE_EQ(1, se3h(0,3));
+  EXPECT_DOUBLE_EQ(0, se3h(1,0));
+  EXPECT_DOUBLE_EQ(1, se3h(1,1));
+  EXPECT_DOUBLE_EQ(0, se3h(1,2));
+  EXPECT_DOUBLE_EQ(2, se3h(1,3));
+  EXPECT_DOUBLE_EQ(0, se3h(2,0));
+  EXPECT_DOUBLE_EQ(0, se3h(2,1));
+  EXPECT_DOUBLE_EQ(1, se3h(2,2));
+  EXPECT_DOUBLE_EQ(3, se3h(2,3));
+}
+
+TEST(TEST_SE3, TEST_SE3_ISOMETRY)
+{
+  Eigen::Isometry3d h = Eigen::Translation3d(1,2,3) * Eigen::Quaterniond::Identity();
+
+  SE3d se3(h);
+
+  Eigen::Isometry3d se3h = se3.isometry();
+
+  EXPECT_DOUBLE_EQ(1, se3h.matrix()(0,0));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(0,1));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(0,2));
+  EXPECT_DOUBLE_EQ(1, se3h.matrix()(0,3));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(1,0));
+  EXPECT_DOUBLE_EQ(1, se3h.matrix()(1,1));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(1,2));
+  EXPECT_DOUBLE_EQ(2, se3h.matrix()(1,3));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(2,0));
+  EXPECT_DOUBLE_EQ(0, se3h.matrix()(2,1));
+  EXPECT_DOUBLE_EQ(1, se3h.matrix()(2,2));
+  EXPECT_DOUBLE_EQ(3, se3h.matrix()(2,3));
+}
+
+
+
 MANIF_TEST(SE3d);
 
 MANIF_TEST_JACOBIANS(SE3d);

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -35,6 +35,21 @@ TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_T_Q)
   EXPECT_DOUBLE_EQ(1, se3.coeffs()(6));
 }
 
+TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_ISOMETRY)
+{
+  Eigen::Isometry3d h = Eigen::Translation3d(1,2,3) * Eigen::Quaterniond::Identity();
+
+  SE3d se3(h);
+
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(2, se3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(3, se3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(3));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(4));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(5));
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(6));
+}
+
 TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_COPY)
 {
   SE3d::DataType values; values << 0,0,0, 0,0,0,1;


### PR DESCRIPTION
Add one new constructor in `SE3`, and the corresponding unit test.

This constructor uses `Eigen::Affine3d` as the input parameter, which is pretty equivalent to an SE3 object: one rotation and one translation.

Note on `Eigen::Affine3d`: `Affine3d` is an alias of `Transform3d`, just that the linear part is marked as a rotation matrix in order to speed up the `inverse()` procedure: we will transpose the linear part assuming it's a rotation matrix, instead of inverting it assuming it is just a matrix.