### PR TITLE
use system/cmake_module find eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if((NOT (DEFINED EIGEN3_VERSION)) AND (DEFINED EIGEN3_VERSION_STRING))
 endif()
 
 if(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
-  message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR},"
+  message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS},"
                   "but this version has a [bug](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1643)")
 endif(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
 
@@ -87,7 +87,7 @@ if(TARGET Eigen3::Eigen)
   target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)
   set(Eigen3_DEPENDENCY "find_dependency(Eigen3 ${Eigen3_VERSION})")
 else(TARGET Eigen3::Eigen)
-  target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE ${EIGEN3_INCLUDE_DIR})
+  target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE ${EIGEN3_INCLUDE_DIRS})
 endif(TARGET Eigen3::Eigen)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,27 @@ else()
     "has no C++11 support. Please use a different C++ compiler.")
 endif()
 
-# Set search directory for looking for our custom CMake scripts
-# to look Eigen3.
-LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+# Finding Eigen is somewhat complicated.
+# First we look for the Eigen3 cmake module
+# provided by the libeigen3-dev on newer Ubuntu. If that fails, then we
+# fall-back to the version provided in the cmake/modules.
+find_package(Eigen3 QUIET)
 
-find_package(Eigen3 REQUIRED)
+if(NOT EIGEN3_FOUND)
+  LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+  find_package(Eigen3 REQUIRED)
+endif()
+
+# Note that eigen 3.2 (on Ubuntu Wily) only provides EIGEN3_INCLUDE_DIR,
+# not EIGEN3_INCLUDE_DIRS, so we have to set the latter from the former.
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
+# Necessary for Ubuntu 16.04's god-awful FindEigen3.cmake.
+if((NOT (DEFINED EIGEN3_VERSION)) AND (DEFINED EIGEN3_VERSION_STRING))
+  set(EIGEN3_VERSION ${EIGEN3_VERSION_STRING})
+endif()
 
 if(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
   message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR},"


### PR DESCRIPTION
Finding Eigen is now two-fold, first looking for cmake module provided by `libeigen3-dev` then falls back on `cmake_module`.

Fix #76 