### PR TITLE
define and use MANIF_PI*

### DIFF
--- a/examples/se2_average.cpp
+++ b/examples/se2_average.cpp
@@ -14,14 +14,14 @@ int main(int /*argc*/, char** /*argv*/)
 
   std::vector<manif::SE2d> points;
 
-//  points.emplace_back(1, 1, 3.*M_PI/4.);
-//  points.emplace_back(1, 3, 5.*M_PI/8.);
-//  points.emplace_back(3, 1,    M_PI/4.);
-//  points.emplace_back(3, 3, 3.*M_PI/8.);
+//  points.emplace_back(1, 1, 3.*MANIF_PI/4.);
+//  points.emplace_back(1, 3, 5.*MANIF_PI/8.);
+//  points.emplace_back(3, 1,    MANIF_PI/4.);
+//  points.emplace_back(3, 3, 3.*MANIF_PI/8.);
 
-  points.emplace_back(-std::sqrt(2.)/2.,  std::sqrt(2.)/2.,  M_PI/4.);
+  points.emplace_back(-std::sqrt(2.)/2.,  std::sqrt(2.)/2.,  MANIF_PI/4.);
   points.emplace_back( std::sqrt(2.),     0.,                0.);
-  points.emplace_back(-std::sqrt(2.)/2., -std::sqrt(2.)/2., -M_PI/4.);
+  points.emplace_back(-std::sqrt(2.)/2., -std::sqrt(2.)/2., -MANIF_PI/4.);
 
   std::cout << "Initial points:\n";
   for (const auto& p : points)

--- a/examples/se2_points_generator.h
+++ b/examples/se2_points_generator.h
@@ -17,12 +17,12 @@ generateSE2PointsOnHeightShape(const unsigned int k)
 
   const double x = std::cos(0);
   const double y = std::sin(0)/2;
-  states.emplace_back(x,y,M_PI/2);
+  states.emplace_back(x,y,MANIF_PI/2);
 
   double t = 0;
   for (unsigned int i=1; i<k; ++i)
   {
-    t += M_PI*2. / double(k);
+    t += MANIF_PI*2. / double(k);
 
     const double x = std::cos(t);
     const double y = std::sin(2.*t) / 2.;

--- a/examples/so2_average.cpp
+++ b/examples/so2_average.cpp
@@ -19,10 +19,10 @@ int main(int argc, char** argv)
 
   std::vector<manif::SO2d> points;
 
-  points.emplace_back(   M_PI/4.);
-  points.emplace_back(3.*M_PI/8.);
-  points.emplace_back(5.*M_PI/8.);
-  points.emplace_back(3.*M_PI/4.);
+  points.emplace_back(   MANIF_PI/4.);
+  points.emplace_back(3.*MANIF_PI/8.);
+  points.emplace_back(5.*MANIF_PI/8.);
+  points.emplace_back(3.*MANIF_PI/4.);
 
   std::cout << "Initial points:\n";
   for (const auto& p : points)

--- a/include/manif/constants.h
+++ b/include/manif/constants.h
@@ -4,6 +4,10 @@
 #include <cmath>
 #include <limits>
 
+#define MANIF_PI   3.141592653589793238462643383279502884
+#define MANIF_PI_2 1.570796326794896619231321691639751442
+#define MANIF_PI_4 0.785398163397448309615660845819875721
+
 namespace manif {
 namespace internal {
 
@@ -45,8 +49,8 @@ struct Constants
   static constexpr _Scalar eps_s    = _Scalar(1e-15); // ~
   static constexpr _Scalar eps_sqrt = internal::csqrt(eps);
 
-  static constexpr _Scalar to_rad = _Scalar(M_PI / 180);
-  static constexpr _Scalar to_deg = _Scalar(180.0 / M_PI);
+  static constexpr _Scalar to_rad = _Scalar(MANIF_PI / 180.0);
+  static constexpr _Scalar to_deg = _Scalar(180.0 / MANIF_PI);
 };
 
 template <typename _Scalar>

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -357,7 +357,7 @@ struct RandomEvaluatorImpl<SE2TangentBase<Derived>>
   static void run(SE2TangentBase<Derived>& m)
   {
     m.coeffs().setRandom();         // in [-1,1]
-    m.coeffs().coeffRef(2) *= M_PI; // in [-PI,PI]
+    m.coeffs().coeffRef(2) *= MANIF_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -433,7 +433,7 @@ struct RandomEvaluatorImpl<SE3TangentBase<Derived>>
   static void run(SE3TangentBase<Derived>& m)
   {
     m.coeffs().setRandom();                // in [-1,1]
-    m.coeffs().template tail<3>() *= M_PI; // in [-PI,PI]
+    m.coeffs().template tail<3>() *= MANIF_PI; // in [-PI,PI]
   }
 };
 

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -216,7 +216,7 @@ struct RandomEvaluatorImpl<SO2TangentBase<Derived>>
   static void run(SO2TangentBase<Derived>& m)
   {
     // in [-1,1]  /  in [-PI,PI]
-    m.coeffs().setRandom() *= M_PI;
+    m.coeffs().setRandom() *= MANIF_PI;
   }
 };
 

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -301,7 +301,7 @@ struct RandomEvaluatorImpl<SO3TangentBase<Derived>>
   static void run(SO3TangentBase<Derived>& m)
   {
     // in [-1,1]  / in [-PI,PI]
-    m.coeffs().setRandom() *= M_PI;
+    m.coeffs().setRandom() *= MANIF_PI;
   }
 };
 

--- a/include/manif/impl/utils.h
+++ b/include/manif/impl/utils.h
@@ -13,8 +13,8 @@ namespace manif {
 template <typename T>
 T pi2pi(T angle)
 {
-  while (angle > T(M_PI))   angle -= T(2. * M_PI);
-  while (angle <= T(-M_PI)) angle += T(2. * M_PI);
+  while (angle > T(MANIF_PI))   angle -= T(2. * MANIF_PI);
+  while (angle <= T(-MANIF_PI)) angle += T(2. * MANIF_PI);
 
   return angle;
 }

--- a/test/ceres/gtest_se2_autodiff.cpp
+++ b/test/ceres/gtest_se2_autodiff.cpp
@@ -23,16 +23,16 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_OBJECTIVE_AUTODIFF)
 {
   // Create 4 objectives spread arround pi
   std::shared_ptr<ceres::CostFunction> obj_pi_over_4 =
-      make_objective_autodiff<SE2d>(3,3,M_PI/4.);
+      make_objective_autodiff<SE2d>(3,3,MANIF_PI/4.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_8 =
-      make_objective_autodiff<SE2d>(3,1,3.*M_PI/8.);
+      make_objective_autodiff<SE2d>(3,1,3.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_5_pi_over_8 =
-      make_objective_autodiff<SE2d>(1,1,5.*M_PI/8.);
+      make_objective_autodiff<SE2d>(1,1,5.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_4 =
-      make_objective_autodiff<SE2d>(1,3,3.*M_PI/4.);
+      make_objective_autodiff<SE2d>(1,3,3.*MANIF_PI/4.);
 
   /// @todo eval Jac
 ////  double** jacobians = new double*[10];
@@ -54,22 +54,22 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_OBJECTIVE_AUTODIFF)
   /// @todo
 //  EXPECT_DOUBLE_EQ(d0, residuals[0]);
 //  EXPECT_DOUBLE_EQ(d0, residuals[1]);
-//  EXPECT_DOUBLE_EQ(1.*M_PI/4., residuals[2]);
+//  EXPECT_DOUBLE_EQ(1.*MANIF_PI/4., residuals[2]);
 
   obj_3_pi_over_8->Evaluate(parameters, residuals, nullptr);
 //  EXPECT_DOUBLE_EQ(3, residuals[0]);
 //  EXPECT_DOUBLE_EQ(1, residuals[1]);
-//  EXPECT_DOUBLE_EQ(3.*M_PI/8., residuals[2]);
+//  EXPECT_DOUBLE_EQ(3.*MANIF_PI/8., residuals[2]);
 
   obj_5_pi_over_8->Evaluate(parameters, residuals, nullptr);
 //  EXPECT_DOUBLE_EQ(1, residuals[0]);
 //  EXPECT_DOUBLE_EQ(3, residuals[1]);
-//  EXPECT_DOUBLE_EQ(5.*M_PI/8., residuals[2]);
+//  EXPECT_DOUBLE_EQ(5.*MANIF_PI/8., residuals[2]);
 
   obj_3_pi_over_4->Evaluate(parameters, residuals, nullptr );
 //  EXPECT_DOUBLE_EQ(1, residuals[0]);
 //  EXPECT_DOUBLE_EQ(1, residuals[1]);
-//  EXPECT_DOUBLE_EQ(3.*M_PI/4., residuals[2]);
+//  EXPECT_DOUBLE_EQ(3.*MANIF_PI/4., residuals[2]);
 }
 
 TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
@@ -81,7 +81,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   // 0 + pi
 
   double x[SE2d::RepSize] = {0.0, 0.0, 1.0, 0.0};
-  double delta[SE2Tangentd::RepSize] = {1.0, 1.0, M_PI};
+  double delta[SE2Tangentd::RepSize] = {1.0, 1.0, MANIF_PI};
   double x_plus_delta[SE2d::RepSize] = {0.0, 0.0, 0.0, 0.0};
 
   auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
@@ -93,16 +93,16 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[2]);
   EXPECT_NEAR(0.0, x_plus_delta[3], 1e-15);
 
-  EXPECT_EQ(M_PI, Eigen::Map<const SE2d>(x_plus_delta).angle());
+  EXPECT_EQ(MANIF_PI, Eigen::Map<const SE2d>(x_plus_delta).angle());
 
   // pi/4 + pi
 
   Eigen::Map<SE2d> map_se2(x);
-  map_se2 = SE2d(1, 1, M_PI/4.);
+  map_se2 = SE2d(1, 1, MANIF_PI/4.);
 
   delta[0] = 1;
   delta[1] = 2;
-  delta[2] = M_PI;
+  delta[2] = MANIF_PI;
   x_plus_delta[0] = 0;
   x_plus_delta[1] = 0;
   x_plus_delta[2] = 1;
@@ -114,10 +114,10 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
 //  EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[0]);
 //  EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[1]);
 
-  EXPECT_DOUBLE_EQ(cos(-3.*M_PI/4.), x_plus_delta[2]);
-  EXPECT_DOUBLE_EQ(sin(-3.*M_PI/4.), x_plus_delta[3]);
+  EXPECT_DOUBLE_EQ(cos(-3.*MANIF_PI/4.), x_plus_delta[2]);
+  EXPECT_DOUBLE_EQ(sin(-3.*MANIF_PI/4.), x_plus_delta[3]);
 
-  EXPECT_NEAR(-3.*M_PI/4., Eigen::Map<const SE2d>(x_plus_delta).angle(), 1e-15);
+  EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SE2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[SE2d::RepSize*SE2Tangentd::RepSize];
   auto_diff_local_parameterization->ComputeJacobian(x, J_rplus);
@@ -148,16 +148,16 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
 
   // Create 4 objectives spread arround pi
   std::shared_ptr<ceres::CostFunction> obj_pi_over_4 =
-      make_objective_autodiff<SE2d>(3,3,M_PI/4.);
+      make_objective_autodiff<SE2d>(3,3,MANIF_PI/4.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_8 =
-      make_objective_autodiff<SE2d>(3,1,3.*M_PI/8.);
+      make_objective_autodiff<SE2d>(3,1,3.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_5_pi_over_8 =
-      make_objective_autodiff<SE2d>(1,1,5.*M_PI/8.);
+      make_objective_autodiff<SE2d>(1,1,5.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_4 =
-      make_objective_autodiff<SE2d>(1,3,3.*M_PI/4.);
+      make_objective_autodiff<SE2d>(1,3,3.*MANIF_PI/4.);
 
   SE2d average_state(0,0,0);
 
@@ -192,7 +192,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
   std::cout << "-----------------------------\n\n";
 
   // Initializing state closer to solution
-//  average_state = SE2d(3.*M_PI/8.);
+//  average_state = SE2d(3.*MANIF_PI/8.);
 
   // Run the solver!
   ceres::Solver::Options options;
@@ -214,7 +214,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
 
   EXPECT_NEAR(2,      average_state.x(),     1e-1);
   EXPECT_NEAR(2,      average_state.y(),     1e-1);
-  EXPECT_NEAR(M_PI_2, average_state.angle(), 1e-1);
+  EXPECT_NEAR(MANIF_PI_2, average_state.angle(), 1e-1);
 }
 
 
@@ -235,25 +235,25 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   ceres::Problem problem(problem_options);
 
-//  p0 expected at  0, 0, -M_PI/4.
+//  p0 expected at  0, 0, -MANIF_PI/4.
 //  p1 expected at  1, 0, 0
-//  p2 expected at  2, 1, M_PI/4.
-//  p3 expected at  2, 2, M_PI/2.
-//  p4 expected at  1, 3, 3.*M_PI/4.
-//  p5 expected at  0, 3, M_PI
-//  p6 expected at -1, 2, -3.*M_PI/4.
-//  p7 expected at -1, 1, -M_PI/2.
+//  p2 expected at  2, 1, MANIF_PI/4.
+//  p3 expected at  2, 2, MANIF_PI/2.
+//  p4 expected at  1, 3, 3.*MANIF_PI/4.
+//  p5 expected at  0, 3, MANIF_PI
+//  p6 expected at -1, 2, -3.*MANIF_PI/4.
+//  p7 expected at -1, 1, -MANIF_PI/2.
 
   GaussianNoiseGenerator<> noise(0, 0.1);
 
-  SE2d state_0( 0 + noise(), 0 + noise(), -M_PI/4.    + noise());
+  SE2d state_0( 0 + noise(), 0 + noise(), -MANIF_PI/4.    + noise());
   SE2d state_1( 1 + noise(), 0 + noise(), 0           + noise());
-  SE2d state_2( 2 + noise(), 1 + noise(), M_PI/4.     + noise());
-  SE2d state_3( 2 + noise(), 2 + noise(), M_PI/2.     + noise());
-  SE2d state_4( 1 + noise(), 3 + noise(), 3.*M_PI/4.  + noise());
-  SE2d state_5( 0 + noise(), 3 + noise(), M_PI        + noise());
-  SE2d state_6(-1 + noise(), 2 + noise(), -3.*M_PI/4. + noise());
-  SE2d state_7(-1 + noise(), 1 + noise(), -M_PI/2.    + noise());
+  SE2d state_2( 2 + noise(), 1 + noise(), MANIF_PI/4.     + noise());
+  SE2d state_3( 2 + noise(), 2 + noise(), MANIF_PI/2.     + noise());
+  SE2d state_4( 1 + noise(), 3 + noise(), 3.*MANIF_PI/4.  + noise());
+  SE2d state_5( 0 + noise(), 3 + noise(), MANIF_PI        + noise());
+  SE2d state_6(-1 + noise(), 2 + noise(), -3.*MANIF_PI/4. + noise());
+  SE2d state_7(-1 + noise(), 1 + noise(), -MANIF_PI/2.    + noise());
 
   std::cout << "Initial states :\n";
   std::cout << "p0 : [" << state_0.x() << "," << state_0.y() << "," << state_0.angle() << "]\n";
@@ -268,14 +268,14 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   double inv_sqrt_2 = 1./sqrt(2.);
 
-  auto constraint_0_1 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, M_PI/4. ).log() );
-  auto constraint_1_2 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          M_PI/4. ).log() );
-  auto constraint_2_3 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, M_PI/4. ).log() );
-  auto constraint_3_4 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          M_PI/4. ).log() );
-  auto constraint_4_5 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, M_PI/4. ).log() );
-  auto constraint_5_6 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          M_PI/4. ).log() );
-  auto constraint_6_7 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, M_PI/4. ).log() );
-  auto constraint_7_0 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          M_PI/4. ).log() );
+  auto constraint_0_1 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, MANIF_PI/4. ).log() );
+  auto constraint_1_2 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          MANIF_PI/4. ).log() );
+  auto constraint_2_3 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, MANIF_PI/4. ).log() );
+  auto constraint_3_4 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          MANIF_PI/4. ).log() );
+  auto constraint_4_5 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, MANIF_PI/4. ).log() );
+  auto constraint_5_6 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          MANIF_PI/4. ).log() );
+  auto constraint_6_7 = make_constraint_autodiff<SE2d>( SE2d( inv_sqrt_2, inv_sqrt_2, MANIF_PI/4. ).log() );
+  auto constraint_7_0 = make_constraint_autodiff<SE2d>( SE2d( 1,          1,          MANIF_PI/4. ).log() );
 
   // Add residual blocks to ceres problem
   problem.AddResidualBlock( constraint_0_1.get(),
@@ -312,7 +312,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   // Anchor on state
   std::shared_ptr<ceres::CostFunction> obj_origin =
-      make_objective_autodiff<SE2d>(0,0,-M_PI/4.);
+      make_objective_autodiff<SE2d>(0,0,-MANIF_PI/4.);
 
   problem.AddResidualBlock( obj_origin.get(),
                             nullptr,
@@ -377,7 +377,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   EXPECT_NEAR( 0,                 state_0.x(),      ceres_eps);
   EXPECT_NEAR( 0,                 state_0.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR(-M_PI/4.,     state_0.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR(-MANIF_PI/4.,     state_0.angle(),  ceres_eps);
 
   EXPECT_NEAR( 1,                 state_1.x(),      ceres_eps);
   EXPECT_NEAR( 0,                 state_1.y(),      ceres_eps);
@@ -385,27 +385,27 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   EXPECT_NEAR( 2,                 state_2.x(),      ceres_eps);
   EXPECT_NEAR( 1,                 state_2.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR( M_PI/4.,     state_2.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR( MANIF_PI/4.,     state_2.angle(),  ceres_eps);
 
   EXPECT_NEAR( 2,                 state_3.x(),      ceres_eps);
   EXPECT_NEAR( 2,                 state_3.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR( M_PI_2,      state_3.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR( MANIF_PI_2,      state_3.angle(),  ceres_eps);
 
   EXPECT_NEAR( 1,                 state_4.x(),      ceres_eps);
   EXPECT_NEAR( 3,                 state_4.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR( 3.*M_PI/4.,  state_4.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR( 3.*MANIF_PI/4.,  state_4.angle(),  ceres_eps);
 
   EXPECT_NEAR( 0,                 state_5.x(),      ceres_eps);
   EXPECT_NEAR( 3,                 state_5.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR(-M_PI,        state_5.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR(-MANIF_PI,        state_5.angle(),  ceres_eps);
 
   EXPECT_NEAR(-1,                 state_6.x(),      ceres_eps);
   EXPECT_NEAR( 2,                 state_6.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR(-3.*M_PI/4,   state_6.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR(-3.*MANIF_PI/4,   state_6.angle(),  ceres_eps);
 
   EXPECT_NEAR(-1,                 state_7.x(),      ceres_eps);
   EXPECT_NEAR( 1,                 state_7.y(),      ceres_eps);
-  EXPECT_ANGLE_NEAR(-M_PI_2,      state_7.angle(),  ceres_eps);
+  EXPECT_ANGLE_NEAR(-MANIF_PI_2,      state_7.angle(),  ceres_eps);
 }
 
 int main(int argc, char** argv)

--- a/test/ceres/gtest_so2_ceres.cpp
+++ b/test/ceres/gtest_so2_ceres.cpp
@@ -9,16 +9,16 @@ TEST(TEST_SO2_CERES, TEST_SO2_OBJECTIVE_AUTODIFF)
 {
   // Create 4 objectives spread arround pi
   std::shared_ptr<ceres::CostFunction> obj_pi_over_4 =
-      make_objective_autodiff<SO2d>(M_PI/4.);
+      make_objective_autodiff<SO2d>(MANIF_PI/4.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_8 =
-      make_objective_autodiff<SO2d>(3.*M_PI/8.);
+      make_objective_autodiff<SO2d>(3.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_5_pi_over_8 =
-      make_objective_autodiff<SO2d>(5.*M_PI/8.);
+      make_objective_autodiff<SO2d>(5.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_4 =
-      make_objective_autodiff<SO2d>(3.*M_PI/4.);
+      make_objective_autodiff<SO2d>(3.*MANIF_PI/4.);
 
   /// @todo eval Jac
 ////  double** jacobians = new double*[10];
@@ -36,16 +36,16 @@ TEST(TEST_SO2_CERES, TEST_SO2_OBJECTIVE_AUTODIFF)
   parameters = &parameter;
 
   obj_pi_over_4->Evaluate(parameters, &residuals, nullptr);
-  EXPECT_DOUBLE_EQ(1.*M_PI/4., residuals);
+  EXPECT_DOUBLE_EQ(1.*MANIF_PI/4., residuals);
 
   obj_3_pi_over_8->Evaluate(parameters, &residuals, nullptr);
-  EXPECT_DOUBLE_EQ(3.*M_PI/8., residuals);
+  EXPECT_DOUBLE_EQ(3.*MANIF_PI/8., residuals);
 
   obj_5_pi_over_8->Evaluate(parameters, &residuals, nullptr);
-  EXPECT_DOUBLE_EQ(5.*M_PI/8., residuals);
+  EXPECT_DOUBLE_EQ(5.*MANIF_PI/8., residuals);
 
   obj_3_pi_over_4->Evaluate(parameters, &residuals, nullptr );
-  EXPECT_DOUBLE_EQ(3.*M_PI/4., residuals);
+  EXPECT_DOUBLE_EQ(3.*MANIF_PI/4., residuals);
 }
 
 TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
@@ -57,7 +57,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   // 0 + pi
 
   double x[2] = {1.0, 0.0};
-  double delta[1] = {M_PI};
+  double delta[1] = {MANIF_PI};
   double x_plus_delta[2] = {0.0, 0.0};
 
   auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
@@ -65,23 +65,23 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[0]);
   EXPECT_NEAR(0.0, x_plus_delta[1], 1e-15);
 
-  EXPECT_EQ(M_PI, Eigen::Map<const SO2d>(x_plus_delta).angle());
+  EXPECT_EQ(MANIF_PI, Eigen::Map<const SO2d>(x_plus_delta).angle());
 
   // pi/4 + pi
 
   Eigen::Map<SO2d> map_so2(x);
-  map_so2 = SO2d(M_PI/4.);
+  map_so2 = SO2d(MANIF_PI/4.);
 
-//  delta[0] = M_PI;
+//  delta[0] = MANIF_PI;
   x_plus_delta[0] = 0;
   x_plus_delta[1] = 0;
 
   auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
 
-  EXPECT_DOUBLE_EQ(cos(-3.*M_PI/4.), x_plus_delta[0]);
-  EXPECT_DOUBLE_EQ(sin(-3.*M_PI/4.), x_plus_delta[1]);
+  EXPECT_DOUBLE_EQ(cos(-3.*MANIF_PI/4.), x_plus_delta[0]);
+  EXPECT_DOUBLE_EQ(sin(-3.*MANIF_PI/4.), x_plus_delta[1]);
 
-  EXPECT_NEAR(-3.*M_PI/4., Eigen::Map<const SO2d>(x_plus_delta).angle(), 1e-15);
+  EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SO2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[2];
   auto_diff_local_parameterization->ComputeJacobian(x, J_rplus);
@@ -101,24 +101,24 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
 
   // Create 4 objectives spread arround pi
   std::shared_ptr<ceres::CostFunction> obj_pi_over_4 =
-      make_objective_autodiff<SO2d>(   M_PI/4.);
+      make_objective_autodiff<SO2d>(   MANIF_PI/4.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_8 =
-      make_objective_autodiff<SO2d>(3.*M_PI/8.);
+      make_objective_autodiff<SO2d>(3.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_5_pi_over_8 =
-      make_objective_autodiff<SO2d>(5.*M_PI/8.);
+      make_objective_autodiff<SO2d>(5.*MANIF_PI/8.);
 
   std::shared_ptr<ceres::CostFunction> obj_3_pi_over_4 =
-      make_objective_autodiff<SO2d>(3.*M_PI/4.);
+      make_objective_autodiff<SO2d>(3.*MANIF_PI/4.);
 
   // Initializing state close to solution
-  SO2d average_state( M_PI/8.);
+  SO2d average_state( MANIF_PI/8.);
 
   /// @note Given the following init point,
   /// Ceres fails in computing derivatives (nans)
   /// when evaluating obj_3_pi_over_8 ...
-//  SO2d average_state(3.*M_PI/8.);
+//  SO2d average_state(3.*MANIF_PI/8.);
 
   // Add residual blocks to ceres problem
   problem.AddResidualBlock( obj_pi_over_4.get(),
@@ -162,7 +162,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
   ASSERT_TRUE(summary.IsSolutionUsable());
 
   // 1.3088223838053636e-09
-  EXPECT_ANGLE_NEAR(M_PI_2, average_state.angle(), 1e-8);
+  EXPECT_ANGLE_NEAR(MANIF_PI_2, average_state.angle(), 1e-8);
 }
 
 TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
@@ -177,22 +177,22 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
   GaussianNoiseGenerator<> noise(0, 0.1);
 
   //  p0 expected at  0
-  //  p1 expected at  M_PI/4.
-  //  p2 expected at  M_PI_2
-  //  p3 expected at  3.*M_PI/4.
-  //  p4 expected at  M_PI
-  //  p5 expected at -3.*M_PI/4
-  //  p6 expected at -M_PI_2
-  //  p7 expected at -M_PI/4.
+  //  p1 expected at  MANIF_PI/4.
+  //  p2 expected at  MANIF_PI_2
+  //  p3 expected at  3.*MANIF_PI/4.
+  //  p4 expected at  MANIF_PI
+  //  p5 expected at -3.*MANIF_PI/4
+  //  p6 expected at -MANIF_PI_2
+  //  p7 expected at -MANIF_PI/4.
 
   SO2d state_0( 0          + noise());
-  SO2d state_1( M_PI/4.    + noise());
-  SO2d state_2( M_PI_2     + noise());
-  SO2d state_3( 3.*M_PI/4. + noise());
-  SO2d state_4( M_PI       + noise());
-  SO2d state_5(-3.*M_PI/4  + noise());
-  SO2d state_6(-M_PI_2     + noise());
-  SO2d state_7(-M_PI/4.    + noise());
+  SO2d state_1( MANIF_PI/4.    + noise());
+  SO2d state_2( MANIF_PI_2     + noise());
+  SO2d state_3( 3.*MANIF_PI/4. + noise());
+  SO2d state_4( MANIF_PI       + noise());
+  SO2d state_5(-3.*MANIF_PI/4  + noise());
+  SO2d state_6(-MANIF_PI_2     + noise());
+  SO2d state_7(-MANIF_PI/4.    + noise());
 
   std::cout << "Initial states :\n";
   std::cout << "p0 : [" << state_0.angle() << "]\n";
@@ -205,14 +205,14 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
   std::cout << "p7 : [" << state_7.angle() << "]\n";
   std::cout << "\n";
 
-  auto constraint_0_1 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_1_2 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_2_3 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_3_4 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_4_5 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_5_6 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_6_7 = make_constraint_autodiff<SO2d>(M_PI/4.);
-  auto constraint_7_0 = make_constraint_autodiff<SO2d>(M_PI/4.);
+  auto constraint_0_1 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_1_2 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_2_3 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_3_4 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_4_5 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_5_6 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_6_7 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
+  auto constraint_7_0 = make_constraint_autodiff<SO2d>(MANIF_PI/4.);
 
   // Add residual blocks to ceres problem
   problem.AddResidualBlock( constraint_0_1.get(),
@@ -314,13 +314,13 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
   constexpr double ceres_eps = 1e-6;
 
   EXPECT_ANGLE_NEAR(0,          state_0.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(M_PI/4.,    state_1.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(M_PI_2,     state_2.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(3.*M_PI/4., state_3.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(M_PI,       state_4.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(-3.*M_PI/4, state_5.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(-M_PI_2,    state_6.angle(), ceres_eps);
-  EXPECT_ANGLE_NEAR(-M_PI/4.,   state_7.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(MANIF_PI/4.,    state_1.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(MANIF_PI_2,     state_2.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(3.*MANIF_PI/4., state_3.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(MANIF_PI,       state_4.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(-3.*MANIF_PI/4, state_5.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(-MANIF_PI_2,    state_6.angle(), ceres_eps);
+  EXPECT_ANGLE_NEAR(-MANIF_PI/4.,   state_7.angle(), ceres_eps);
 }
 
 MANIF_TEST_JACOBIANS_CERES(SO2d);

--- a/test/se2/gtest_se2.cpp
+++ b/test/se2/gtest_se2.cpp
@@ -40,7 +40,7 @@ TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_COPY)
 
   EXPECT_DOUBLE_EQ(4, se2.x());
   EXPECT_DOUBLE_EQ(2, se2.y());
-  EXPECT_DOUBLE_EQ(M_PI/4., se2.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI/4., se2.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_COEFFS)
@@ -152,13 +152,13 @@ TEST(TEST_SE2, TEST_SE2_ROTATION)
 TEST(TEST_SE2, TEST_SE2_ASSIGN_OP)
 {
   SE2d se2a(0, 0, 0);
-  SE2d se2b(4, 2, M_PI);
+  SE2d se2b(4, 2, MANIF_PI);
 
   se2a = se2b;
 
   EXPECT_DOUBLE_EQ(4, se2a.x());
   EXPECT_DOUBLE_EQ(2, se2a.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2a.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_INVERSE)
@@ -173,18 +173,18 @@ TEST(TEST_SE2, TEST_SE2_INVERSE)
   EXPECT_DOUBLE_EQ(1, se2_inv.real());
   EXPECT_DOUBLE_EQ(0, se2_inv.imag());
 
-  se2 = SE2d(1, 1, M_PI);
+  se2 = SE2d(1, 1, MANIF_PI);
   se2_inv = se2.inverse();
 
   EXPECT_DOUBLE_EQ( 1, se2_inv.x());
   EXPECT_DOUBLE_EQ( 1, se2_inv.y());
-  EXPECT_DOUBLE_EQ(-M_PI, se2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, se2_inv.angle());
   EXPECT_DOUBLE_EQ(-1, se2_inv.real());
 //  EXPECT_DOUBLE_EQ(0, se2_inv.imag());
   EXPECT_NEAR(0, se2_inv.imag(), 1e-15);
 
 
-  se2 = SE2d(0.7, 2.3, M_PI/3.);
+  se2 = SE2d(0.7, 2.3, MANIF_PI/3.);
   se2_inv = se2.inverse();
 
   EXPECT_DOUBLE_EQ(-2.341858428704209, se2_inv.x());
@@ -195,91 +195,91 @@ TEST(TEST_SE2, TEST_SE2_INVERSE)
 
 TEST(TEST_SE2, TEST_SE2_RPLUS_ZERO)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
   SE2Tangentd se2b(0, 0, 0);
 
   auto se2c = se2a.rplus(se2b);
 
   EXPECT_DOUBLE_EQ(1, se2c.x());
   EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI/2., se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI/2., se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_RPLUS)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.rplus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_LPLUS_ZERO)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
   SE2Tangentd se2b(0, 0, 0);
 
   auto se2c = se2a.lplus(se2b);
 
   EXPECT_DOUBLE_EQ(1, se2c.x());
   EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI / 2., se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI / 2., se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_LPLUS)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.lplus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_PLUS)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.plus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_OP_PLUS)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a + se2b;
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_OP_PLUS_EQ)
 {
-  SE2d se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  SE2d se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   se2a += se2b;
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2a.x());
 //  EXPECT_DOUBLE_EQ(2, se2a.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2a.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_RMINUS_ZERO)
@@ -298,8 +298,8 @@ TEST(TEST_SE2, TEST_SE2_RMINUS_ZERO)
 
 TEST(TEST_SE2, TEST_SE2_RMINUS_I)
 {
-  SE2d se2a(1, 1, M_PI);
-  SE2d se2b(1, 1, M_PI);
+  SE2d se2a(1, 1, MANIF_PI);
+  SE2d se2b(1, 1, MANIF_PI);
 
   auto se2c = se2a.rminus(se2b);
 
@@ -313,15 +313,15 @@ TEST(TEST_SE2, TEST_SE2_RMINUS_I)
 
 TEST(TEST_SE2, TEST_SE2_RMINUS)
 {
-  SE2d se2a(1, 1, M_PI);
-  SE2d se2b(2, 2, M_PI_2);
+  SE2d se2a(1, 1, MANIF_PI);
+  SE2d se2b(2, 2, MANIF_PI_2);
 
   auto se2c = se2a.rminus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_LMINUS_IDENTITY)
@@ -339,82 +339,82 @@ TEST(TEST_SE2, TEST_SE2_LMINUS_IDENTITY)
 
 TEST(TEST_SE2, TEST_SE2_LMINUS)
 {
-  SE2d se2a(1,1,M_PI);
-  SE2d se2b(2,2,M_PI_2);
+  SE2d se2a(1,1,MANIF_PI);
+  SE2d se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.lminus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(0, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MINUS)
 {
-  SE2d se2a(1, 1, M_PI);
-  SE2d se2b(2, 2, M_PI_2);
+  SE2d se2a(1, 1, MANIF_PI);
+  SE2d se2b(2, 2, MANIF_PI_2);
 
   auto se2c = se2a.minus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_LIFT)
 {
-  SE2d se2(1,1,M_PI);
+  SE2d se2(1,1,MANIF_PI);
 
   auto se2_log = se2.log();
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2_log.x());
 //  EXPECT_DOUBLE_EQ(1, se2_log.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2_log.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_COMPOSE)
 {
-  SE2d se2a(1,1,M_PI_2);
-  SE2d se2b(2,2,M_PI_2);
+  SE2d se2a(1,1,MANIF_PI_2);
+  SE2d se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.compose(se2b);
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(+3, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_OP_COMPOSE)
 {
-  SE2d se2a(1,1,M_PI_2);
-  SE2d se2b(2,2,M_PI_2);
+  SE2d se2a(1,1,MANIF_PI_2);
+  SE2d se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a * se2b;
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(+3, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_OP_COMPOSE_EQ)
 {
-  SE2d se2a(1,1,M_PI_2);
-  SE2d se2b(2,2,M_PI_2);
+  SE2d se2a(1,1,MANIF_PI_2);
+  SE2d se2b(2,2,MANIF_PI_2);
 
   se2a *= se2b;
 
   EXPECT_DOUBLE_EQ(-1, se2a.x());
   EXPECT_DOUBLE_EQ(+3, se2a.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2a.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_BETWEEN_I)
 {
-  SE2d se2a(1,1,M_PI);
-  SE2d se2b(1,1,M_PI);
+  SE2d se2a(1,1,MANIF_PI);
+  SE2d se2b(1,1,MANIF_PI);
 
   auto se2c = se2a.between(se2b);
 
@@ -425,19 +425,19 @@ TEST(TEST_SE2, TEST_SE2_BETWEEN_I)
 
 TEST(TEST_SE2, TEST_SE2_BETWEEN)
 {
-  SE2d se2a(1,1,M_PI);
-  SE2d se2b(2,2,M_PI_2);
+  SE2d se2a(1,1,MANIF_PI);
+  SE2d se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.between(se2b);
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(-1, se2c.y());
-  EXPECT_DOUBLE_EQ(-M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_ACT)
 {
-  SE2d se2(1,1,M_PI/2.);
+  SE2d se2(1,1,MANIF_PI/2.);
 
   auto transformed_point = se2.act(Eigen::Vector2d(1,1));
 
@@ -448,7 +448,7 @@ TEST(TEST_SE2, TEST_SE2_ACT)
   EXPECT_NEAR(0, transformed_point.x(), 1e-15);
   EXPECT_NEAR(2, transformed_point.y(), 1e-15);
 
-  se2 = SE2d(1,1,-M_PI/2.);
+  se2 = SE2d(1,1,-MANIF_PI/2.);
 
   transformed_point = se2.act(Eigen::Vector2d(1,1));
 

--- a/test/se2/gtest_se2_map.cpp
+++ b/test/se2/gtest_se2_map.cpp
@@ -13,7 +13,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_CONSTRUCTOR)
 
   EXPECT_DOUBLE_EQ(4,    se2.x());
   EXPECT_DOUBLE_EQ(2,    se2.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_COEFFS)
@@ -53,13 +53,13 @@ TEST(TEST_SE2, TEST_SE2_MAP_CAST)
 
   EXPECT_DOUBLE_EQ(4, se2d.x());
   EXPECT_DOUBLE_EQ(2, se2d.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2d.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2d.angle());
 
   SE2f se2f = se2d.cast<float>();
 
   EXPECT_FLOAT_EQ(4, se2f.x());
   EXPECT_FLOAT_EQ(2, se2f.y());
-  EXPECT_FLOAT_EQ(M_PI, se2f.angle());
+  EXPECT_FLOAT_EQ(MANIF_PI, se2f.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_IDENTITY)
@@ -156,7 +156,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_ASSIGN_OP)
 
   EXPECT_DOUBLE_EQ(-4, se2a.x());
   EXPECT_DOUBLE_EQ(-2, se2a.y());
-  EXPECT_ANGLE_NEAR(-M_PI, se2a.angle(), 1e-15);
+  EXPECT_ANGLE_NEAR(-MANIF_PI, se2a.angle(), 1e-15);
 
   EXPECT_DOUBLE_EQ(datab[0], dataa[0]);
   EXPECT_DOUBLE_EQ(datab[1], dataa[1]);
@@ -177,16 +177,16 @@ TEST(TEST_SE2, TEST_SE2_MAP_INVERSE)
   EXPECT_DOUBLE_EQ(1, se2_inv.real());
   EXPECT_DOUBLE_EQ(0, se2_inv.imag());
 
-  se2 = SE2d(1, 1, M_PI);
+  se2 = SE2d(1, 1, MANIF_PI);
   se2_inv = se2.inverse();
 
   EXPECT_DOUBLE_EQ( 1, se2_inv.x());
   EXPECT_DOUBLE_EQ( 1, se2_inv.y());
-  EXPECT_ANGLE_NEAR(-M_PI, se2_inv.angle(), 1e-15);
+  EXPECT_ANGLE_NEAR(-MANIF_PI, se2_inv.angle(), 1e-15);
   EXPECT_DOUBLE_EQ(-1, se2_inv.real());
   EXPECT_NEAR(0, se2_inv.imag(), 1e-15);
 
-  se2 = SE2d(0.7, 2.3, M_PI/3.);
+  se2 = SE2d(0.7, 2.3, MANIF_PI/3.);
   se2_inv = se2.inverse();
 
   EXPECT_DOUBLE_EQ(-2.341858428704209, se2_inv.x());
@@ -205,84 +205,84 @@ TEST(TEST_SE2, TEST_SE2_MAP_RPLUS_ZERO)
 
   EXPECT_DOUBLE_EQ(1, se2c.x());
   EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_ANGLE_NEAR(-M_PI, se2c.angle(), 1e-15);
+  EXPECT_ANGLE_NEAR(-MANIF_PI, se2c.angle(), 1e-15);
 }
 /*
 TEST(TEST_SE2, TEST_SE2_MAP_RPLUS)
 {
-  Eigen::Map<SE2d> se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d> se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.rplus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_LPLUS_ZERO)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI / 2.);
   SE2Tangentd se2b(0, 0, 0);
 
   auto se2c = se2a.lplus(se2b);
 
   EXPECT_DOUBLE_EQ(1, se2c.x());
   EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI / 2., se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI / 2., se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_LPLUS)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.lplus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_PLUS)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a.plus(se2b);
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_OP_PLUS)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   auto se2c = se2a + se2b;
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(2, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_OP_PLUS_EQ)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI / 2.);
-  SE2Tangentd se2b(1, 1, M_PI / 2.);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI / 2.);
+  SE2Tangentd se2b(1, 1, MANIF_PI / 2.);
 
   se2a += se2b;
 
   /// @todo what to expect here ?? :S
 //  EXPECT_DOUBLE_EQ(0, se2a.x());
 //  EXPECT_DOUBLE_EQ(2, se2a.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2a.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_ZERO)
@@ -301,8 +301,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_ZERO)
 
 TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_I)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI);
-  Eigen::Map<SE2d>se2b(1, 1, M_PI);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI);
+  Eigen::Map<SE2d>se2b(1, 1, MANIF_PI);
 
   auto se2c = se2a.rminus(se2b);
 
@@ -316,15 +316,15 @@ TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_I)
 
 TEST(TEST_SE2, TEST_SE2_MAP_RMINUS)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI);
-  Eigen::Map<SE2d>se2b(2, 2, M_PI_2);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI);
+  Eigen::Map<SE2d>se2b(2, 2, MANIF_PI_2);
 
   auto se2c = se2a.rminus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_LMINUS_IDENTITY)
@@ -342,82 +342,82 @@ TEST(TEST_SE2, TEST_SE2_MAP_LMINUS_IDENTITY)
 
 TEST(TEST_SE2, TEST_SE2_MAP_LMINUS)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI);
-  Eigen::Map<SE2d>se2b(2,2,M_PI_2);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI);
+  Eigen::Map<SE2d>se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.lminus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(0, se2c.x());
 //  EXPECT_DOUBLE_EQ(0, se2c.y());
-  EXPECT_DOUBLE_EQ(-M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_MINUS)
 {
-  Eigen::Map<SE2d>se2a(1, 1, M_PI);
-  Eigen::Map<SE2d>se2b(2, 2, M_PI_2);
+  Eigen::Map<SE2d>se2a(1, 1, MANIF_PI);
+  Eigen::Map<SE2d>se2b(2, 2, MANIF_PI_2);
 
   auto se2c = se2a.minus(se2b);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2c.x());
 //  EXPECT_DOUBLE_EQ(1, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_LIFT)
 {
-  Eigen::Map<SE2d>se2(1,1,M_PI);
+  Eigen::Map<SE2d>se2(1,1,MANIF_PI);
 
   auto se2_log = se2.log();
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(1, se2_log.x());
 //  EXPECT_DOUBLE_EQ(1, se2_log.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2_log.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_COMPOSE)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI_2);
-  Eigen::Map<SE2d>se2b(2,2,M_PI_2);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI_2);
+  Eigen::Map<SE2d>se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.compose(se2b);
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(+3, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_OP_COMPOSE)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI_2);
-  Eigen::Map<SE2d>se2b(2,2,M_PI_2);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI_2);
+  Eigen::Map<SE2d>se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a * se2b;
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(+3, se2c.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_OP_COMPOSE_EQ)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI_2);
-  Eigen::Map<SE2d>se2b(2,2,M_PI_2);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI_2);
+  Eigen::Map<SE2d>se2b(2,2,MANIF_PI_2);
 
   se2a *= se2b;
 
   EXPECT_DOUBLE_EQ(-1, se2a.x());
   EXPECT_DOUBLE_EQ(+3, se2a.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2a.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_MAP_BETWEEN_I)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI);
-  Eigen::Map<SE2d>se2b(1,1,M_PI);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI);
+  Eigen::Map<SE2d>se2b(1,1,MANIF_PI);
 
   auto se2c = se2a.between(se2b);
 
@@ -428,14 +428,14 @@ TEST(TEST_SE2, TEST_SE2_MAP_BETWEEN_I)
 
 TEST(TEST_SE2, TEST_SE2_MAP_BETWEEN)
 {
-  Eigen::Map<SE2d>se2a(1,1,M_PI);
-  Eigen::Map<SE2d>se2b(2,2,M_PI_2);
+  Eigen::Map<SE2d>se2a(1,1,MANIF_PI);
+  Eigen::Map<SE2d>se2b(2,2,MANIF_PI_2);
 
   auto se2c = se2a.between(se2b);
 
   EXPECT_DOUBLE_EQ(-1, se2c.x());
   EXPECT_DOUBLE_EQ(-1, se2c.y());
-  EXPECT_DOUBLE_EQ(-M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, se2c.angle());
 }
 */
 
@@ -458,10 +458,10 @@ TEST(TEST_SE2, TEST_SE2_MAP_INVERSE_JAC)
   EXPECT_EQ(1, J_inv.cols());
   EXPECT_DOUBLE_EQ(-1, J_inv(0));
 
-  se2 = SE2d(M_PI);
+  se2 = SE2d(MANIF_PI);
   se2.inverse(se2_inv, J_inv);
 
-  EXPECT_DOUBLE_EQ(-M_PI, se2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, se2_inv.angle());
 
   EXPECT_EQ(1, J_inv.rows());
   EXPECT_EQ(1, J_inv.cols());
@@ -470,14 +470,14 @@ TEST(TEST_SE2, TEST_SE2_MAP_INVERSE_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_LIFT_JAC)
 {
-  Eigen::Map<SE2d>se2(M_PI);
+  Eigen::Map<SE2d>se2(MANIF_PI);
 
   SE2d::Tangent se2_log;
   SE2d::Tangent::Jacobian J_log;
 
   se2.log(se2_log, J_log);
 
-  EXPECT_DOUBLE_EQ(M_PI, se2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2_log.angle());
 
   /// @todo check this J
   EXPECT_EQ(1, J_log.rows());
@@ -487,15 +487,15 @@ TEST(TEST_SE2, TEST_SE2_MAP_LIFT_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_COMPOSE_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI_2);
-  Eigen::Map<SE2d>se2b(M_PI_2);
+  Eigen::Map<SE2d>se2a(MANIF_PI_2);
+  Eigen::Map<SE2d>se2b(MANIF_PI_2);
 
   Eigen::Map<SE2d>se2c;
   SE2d::Jacobian J_c_a, J_c_b;
 
   se2a.compose(se2b, se2c, J_c_a, J_c_b);
 
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 
   EXPECT_EQ(1, J_c_a.rows());
   EXPECT_EQ(1, J_c_a.cols());
@@ -508,8 +508,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_COMPOSE_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_RPLUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI / 2.);
-  SE2Tangentd se2b(M_PI / 2.);
+  Eigen::Map<SE2d>se2a(MANIF_PI / 2.);
+  SE2Tangentd se2b(MANIF_PI / 2.);
 
   Eigen::Map<SE2d>se2c;
   SE2d::Jacobian J_rplus_m;
@@ -517,7 +517,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_RPLUS_JAC)
 
   se2a.rplus(se2b, se2c, J_rplus_m, J_rplus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 
   EXPECT_EQ(1, J_rplus_m.rows());
   EXPECT_EQ(1, J_rplus_m.cols());
@@ -530,8 +530,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_RPLUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_LPLUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI / 2.);
-  SE2Tangentd se2b(M_PI / 2.);
+  Eigen::Map<SE2d>se2a(MANIF_PI / 2.);
+  SE2Tangentd se2b(MANIF_PI / 2.);
 
   Eigen::Map<SE2d>se2c;
   SE2d::Jacobian J_lplus_t;
@@ -539,7 +539,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_LPLUS_JAC)
 
   se2a.lplus(se2b, se2c, J_lplus_t, J_lplus_m);
 
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 
   EXPECT_EQ(1, J_lplus_t.rows());
   EXPECT_EQ(1, J_lplus_t.cols());
@@ -552,8 +552,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_LPLUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_PLUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI / 2.);
-  SE2Tangentd se2b(M_PI / 2.);
+  Eigen::Map<SE2d>se2a(MANIF_PI / 2.);
+  SE2Tangentd se2b(MANIF_PI / 2.);
 
   Eigen::Map<SE2d>se2c;
   SE2d::Jacobian J_plus_m;
@@ -561,7 +561,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_PLUS_JAC)
 
   se2a.plus(se2b, se2c, J_plus_m, J_plus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2c.angle());
 
   EXPECT_EQ(1, J_plus_m.rows());
   EXPECT_EQ(1, J_plus_m.cols());
@@ -574,8 +574,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_PLUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI);
-  Eigen::Map<SE2d>se2b(M_PI_2);
+  Eigen::Map<SE2d>se2a(MANIF_PI);
+  Eigen::Map<SE2d>se2b(MANIF_PI_2);
 
   SE2Tangentd se2c;
 
@@ -583,7 +583,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_JAC)
 
   se2a.rminus(se2b, se2c, J_rminus_a, J_rminus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 
   EXPECT_EQ(1, J_rminus_a.rows());
   EXPECT_EQ(1, J_rminus_a.cols());
@@ -596,8 +596,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_RMINUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_LMINUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI);
-  Eigen::Map<SE2d>se2b(M_PI_2);
+  Eigen::Map<SE2d>se2a(MANIF_PI);
+  Eigen::Map<SE2d>se2b(MANIF_PI_2);
 
   SE2Tangentd se2c;
 
@@ -605,7 +605,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_LMINUS_JAC)
 
   se2a.lminus(se2b, se2c, J_lminus_a, J_lminus_b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, se2c.angle());
 
   EXPECT_EQ(1, J_lminus_a.rows());
   EXPECT_EQ(1, J_lminus_a.cols());
@@ -618,8 +618,8 @@ TEST(TEST_SE2, TEST_SE2_MAP_LMINUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_MINUS_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI);
-  Eigen::Map<SE2d>se2b(M_PI_2);
+  Eigen::Map<SE2d>se2a(MANIF_PI);
+  Eigen::Map<SE2d>se2b(MANIF_PI_2);
 
   SE2Tangentd se2c;
 
@@ -627,7 +627,7 @@ TEST(TEST_SE2, TEST_SE2_MAP_MINUS_JAC)
 
   se2a.minus(se2b, se2c, J_minus_a, J_minus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, se2c.angle());
 
   EXPECT_EQ(1, J_minus_a.rows());
   EXPECT_EQ(1, J_minus_a.cols());
@@ -640,15 +640,15 @@ TEST(TEST_SE2, TEST_SE2_MAP_MINUS_JAC)
 
 TEST(TEST_SE2, TEST_SE2_MAP_BETWEEN_JAC)
 {
-  Eigen::Map<SE2d>se2a(M_PI);
-  Eigen::Map<SE2d>se2b(M_PI_2);
+  Eigen::Map<SE2d>se2a(MANIF_PI);
+  Eigen::Map<SE2d>se2b(MANIF_PI_2);
 
   SE2d::Jacobian J_between_a, J_between_b;
   Eigen::Map<SE2d>se2c;
 
   se2a.between(se2b, se2c, J_between_a, J_between_b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, se2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, se2c.angle());
 
   EXPECT_EQ(1, J_between_a.rows());
   EXPECT_EQ(1, J_between_a.cols());

--- a/test/se2/gtest_se2_tangent.cpp
+++ b/test/se2/gtest_se2_tangent.cpp
@@ -6,23 +6,23 @@ using namespace manif;
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_0)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_DATA)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
 
   EXPECT_NE(nullptr, so2tan.data());
 }
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_ZERO)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
 
   so2tan.setZero();
 
@@ -33,7 +33,7 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_ZERO)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_ZERO2)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
   so2tan = SE2Tangentd::Zero();
 
   EXPECT_DOUBLE_EQ(0, so2tan.x());
@@ -59,17 +59,17 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_ZERO2)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_RETRACT)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   auto so2_exp = so2tan.exp();
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo what to expect ? :S
 //  EXPECT_DOUBLE_EQ(0, so2_exp.x());
@@ -80,18 +80,18 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_RETRACT)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_RETRACT_JAC)
 {
-  SE2Tangentd so2tan(4,2,M_PI);
+  SE2Tangentd so2tan(4,2,MANIF_PI);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   SE2d::Jacobian J_ret;
   SE2d so2_exp = so2tan.exp(J_ret);
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo what to expect ? :S
 //  EXPECT_DOUBLE_EQ(0, so2_exp.x());
@@ -107,17 +107,17 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_INSTREAM)
 {
   SE2Tangentd se2;
 
-  se2 << 4, 2, M_PI;
+  se2 << 4, 2, MANIF_PI;
 
   EXPECT_DOUBLE_EQ(4,    se2.x());
   EXPECT_DOUBLE_EQ(2,    se2.y());
-  EXPECT_DOUBLE_EQ(M_PI, se2.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, se2.angle());
 
-  se2 << 3.5, 3.5, M_PI_4;
+  se2 << 3.5, 3.5, MANIF_PI_4;
 
   EXPECT_DOUBLE_EQ(3.5,    se2.x());
   EXPECT_DOUBLE_EQ(3.5,    se2.y());
-  EXPECT_DOUBLE_EQ(M_PI_4, se2.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_4, se2.angle());
 
   typename SE2Tangentd::DataType data(1,2,3);
   se2 << data;

--- a/test/se2/gtest_se2_tangent_map.cpp
+++ b/test/se2/gtest_se2_tangent_map.cpp
@@ -6,12 +6,12 @@ using namespace manif;
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_0)
 {
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 }
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_DATA)
@@ -19,7 +19,7 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_DATA)
   /// @todo without specifying const
   /// it calls non-const data()
 
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
 
   EXPECT_NE(nullptr, so2tan.data());
@@ -28,7 +28,7 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_DATA)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_ZERO)
 {
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
 
   so2tan.setZero();
@@ -40,7 +40,7 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_ZERO)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_ZERO2)
 {
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
   so2tan = SE2Tangentd::Zero();
 
@@ -67,18 +67,18 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_ZERO2)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_RETRACT)
 {
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   auto so2_exp = so2tan.exp();
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo what to expect ? :S
 //  EXPECT_DOUBLE_EQ(0, so2_exp.x());
@@ -89,19 +89,19 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_RETRACT)
 
 TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_RETRACT_JAC)
 {
-  double data[3] = {4,2,M_PI};
+  double data[3] = {4,2,MANIF_PI};
   Eigen::Map<SE2Tangentd> so2tan(data);
 
   EXPECT_DOUBLE_EQ(4, so2tan.x());
   EXPECT_DOUBLE_EQ(2, so2tan.y());
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   SE2d::Jacobian J_ret;
   SE2d so2_exp = so2tan.exp(J_ret);
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo what to expect ? :S
 //  EXPECT_DOUBLE_EQ(0, so2_exp.x());

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -254,7 +254,7 @@ TEST(TEST_SE3, TEST_SE3_ACT)
   EXPECT_NEAR(+1, transformed_point.y(), 1e-15);
   EXPECT_NEAR(+1, transformed_point.z(), 1e-15);
 
-  se3 = SE3d(1,1,1,M_PI,M_PI_2,M_PI/4.);
+  se3 = SE3d(1,1,1,MANIF_PI,MANIF_PI_2,MANIF_PI/4.);
 
   transformed_point = se3.act(Eigen::Vector3d(1,1,1));
 
@@ -262,7 +262,7 @@ TEST(TEST_SE3, TEST_SE3_ACT)
   EXPECT_NEAR(-0.414213562373, transformed_point.y(), 1e-12);
   EXPECT_NEAR( 0, transformed_point.z(), 1e-15);
 
-  se3 = SE3d(-1,-1,-1,M_PI/4,-M_PI_2,-M_PI);
+  se3 = SE3d(-1,-1,-1,MANIF_PI/4,-MANIF_PI_2,-MANIF_PI);
 
   transformed_point = se3.act(Eigen::Vector3d(1,1,1));
 

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -36,7 +36,7 @@ TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_COPY)
 {
   SO2d so2(SO2d(1,1));
 
-  EXPECT_DOUBLE_EQ(M_PI/4., so2.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI/4., so2.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_COEFFS)
@@ -134,11 +134,11 @@ TEST(TEST_SO2, TEST_SO2_ROTATION)
 TEST(TEST_SO2, TEST_SO2_ASSIGN_OP)
 {
   SO2d so2a(0);
-  SO2d so2b(M_PI);
+  SO2d so2b(MANIF_PI);
 
   so2a = so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2a.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_INVERSE)
@@ -151,149 +151,149 @@ TEST(TEST_SO2, TEST_SO2_INVERSE)
   EXPECT_DOUBLE_EQ(1, so2_inv.real());
   EXPECT_DOUBLE_EQ(0, so2_inv.imag());
 
-  so2 = SO2d(M_PI);
+  so2 = SO2d(MANIF_PI);
   so2_inv = so2.inverse();
 
-  EXPECT_DOUBLE_EQ(-M_PI, so2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_inv.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_RPLUS)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   auto so2c = so2a.rplus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_LPLUS)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   auto so2c = so2a.lplus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_PLUS)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   auto so2c = so2a.plus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_OP_PLUS)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   auto so2c = so2a + so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_OP_PLUS_EQ)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   so2a += so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2a.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_RMINUS)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a.rminus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_RMINUS2)
 {
-  SO2d so2a(3.*M_PI/8.);
+  SO2d so2a(3.*MANIF_PI/8.);
   SO2d so2b(0);
 
   auto so2c = so2a.rminus(so2b);
 
-  EXPECT_DOUBLE_EQ(3.*M_PI/8., so2c.angle());
+  EXPECT_DOUBLE_EQ(3.*MANIF_PI/8., so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_LMINUS)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a.lminus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MINUS)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a.minus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_LIFT)
 {
-  SO2d so2(M_PI);
+  SO2d so2(MANIF_PI);
 
   auto so2_log = so2.log();
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_log.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_COMPOSE)
 {
-  SO2d so2a(M_PI_2);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a.compose(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_OP_COMPOSE)
 {
-  SO2d so2a(M_PI_2);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a * so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_OP_COMPOSE_EQ)
 {
-  SO2d so2a(M_PI_2);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2d so2b(MANIF_PI_2);
 
   so2a *= so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2a.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_BETWEEN)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   auto so2c = so2a.between(so2b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2c.angle());
 }
 
 /// with Jacs
@@ -313,10 +313,10 @@ TEST(TEST_SO2, TEST_SO2_INVERSE_JAC)
   EXPECT_EQ(1, J_inv.cols());
   EXPECT_DOUBLE_EQ(-1, J_inv(0));
 
-  so2 = SO2d(M_PI);
+  so2 = SO2d(MANIF_PI);
   so2_inv = so2.inverse(J_inv);
 
-  EXPECT_DOUBLE_EQ(-M_PI, so2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_inv.angle());
 
   EXPECT_EQ(1, J_inv.rows());
   EXPECT_EQ(1, J_inv.cols());
@@ -325,12 +325,12 @@ TEST(TEST_SO2, TEST_SO2_INVERSE_JAC)
 
 TEST(TEST_SO2, TEST_SO2_LIFT_JAC)
 {
-  SO2d so2(M_PI);
+  SO2d so2(MANIF_PI);
 
   SO2d::Tangent::Jacobian J_log;
   SO2d::Tangent so2_log = so2.log(J_log);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_log.angle());
 
   /// @todo check this J
   EXPECT_EQ(1, J_log.rows());
@@ -340,15 +340,15 @@ TEST(TEST_SO2, TEST_SO2_LIFT_JAC)
 
 TEST(TEST_SO2, TEST_SO2_COMPOSE_JAC)
 {
-  SO2d so2a(M_PI_2);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d::Jacobian J_c_a, J_c_b;
   SO2d so2c = so2a.compose(so2b, J_c_a, J_c_b);
 
   so2c = so2a.compose(so2b, SO2d::_, J_c_b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_c_a.rows());
   EXPECT_EQ(1, J_c_a.cols());
@@ -361,15 +361,15 @@ TEST(TEST_SO2, TEST_SO2_COMPOSE_JAC)
 
 TEST(TEST_SO2, TEST_SO2_RPLUS_JAC)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   SO2d::Jacobian J_rplus_m;
   SO2d::Jacobian J_rplus_t;
 
   SO2d so2c = so2a.rplus(so2b, J_rplus_m, J_rplus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_rplus_m.rows());
   EXPECT_EQ(1, J_rplus_m.cols());
@@ -382,15 +382,15 @@ TEST(TEST_SO2, TEST_SO2_RPLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_LPLUS_JAC)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   SO2d::Jacobian J_lplus_t;
   SO2d::Jacobian J_lplus_m;
 
   SO2d so2c = so2a.lplus(so2b, J_lplus_t, J_lplus_m);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_lplus_t.rows());
   EXPECT_EQ(1, J_lplus_t.cols());
@@ -403,15 +403,15 @@ TEST(TEST_SO2, TEST_SO2_LPLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_PLUS_JAC)
 {
-  SO2d so2a(M_PI / 2.);
-  SO2Tangentd so2b(M_PI / 2.);
+  SO2d so2a(MANIF_PI / 2.);
+  SO2Tangentd so2b(MANIF_PI / 2.);
 
   SO2d::Jacobian J_plus_m;
   SO2d::Jacobian J_plus_t;
 
   SO2d so2c = so2a.plus(so2b, J_plus_m, J_plus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_plus_m.rows());
   EXPECT_EQ(1, J_plus_m.cols());
@@ -424,14 +424,14 @@ TEST(TEST_SO2, TEST_SO2_PLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_RMINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d::Jacobian J_rminus_a, J_rminus_b;
 
   SO2Tangentd so2c = so2a.rminus(so2b, J_rminus_a, J_rminus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_rminus_a.rows());
   EXPECT_EQ(1, J_rminus_a.cols());
@@ -444,14 +444,14 @@ TEST(TEST_SO2, TEST_SO2_RMINUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_LMINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d::Jacobian J_lminus_a, J_lminus_b;
 
   SO2Tangentd so2c = so2a.lminus(so2b, J_lminus_a, J_lminus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_lminus_a.rows());
   EXPECT_EQ(1, J_lminus_a.cols());
@@ -464,14 +464,14 @@ TEST(TEST_SO2, TEST_SO2_LMINUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d::Jacobian J_minus_a, J_minus_b;
 
   SO2Tangentd so2c = so2a.minus(so2b, J_minus_a, J_minus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_minus_a.rows());
   EXPECT_EQ(1, J_minus_a.cols());
@@ -484,13 +484,13 @@ TEST(TEST_SO2, TEST_SO2_MINUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_BETWEEN_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d::Jacobian J_between_a, J_between_b;
   SO2d so2c = so2a.between(so2b, J_between_a, J_between_b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_between_a.rows());
   EXPECT_EQ(1, J_between_a.cols());
@@ -503,7 +503,7 @@ TEST(TEST_SO2, TEST_SO2_BETWEEN_JAC)
 
 TEST(TEST_SO2, TEST_SO2_ACT)
 {
-  SO2d so2(M_PI/2.);
+  SO2d so2(MANIF_PI/2.);
 
   auto transformed_point = so2.act(Eigen::Vector2d(1,1));
 
@@ -514,7 +514,7 @@ TEST(TEST_SO2, TEST_SO2_ACT)
   EXPECT_NEAR(-1, transformed_point.x(), 1e-15);
   EXPECT_NEAR(+1, transformed_point.y(), 1e-15);
 
-  so2 = SO2d(-M_PI/2.);
+  so2 = SO2d(-MANIF_PI/2.);
 
   transformed_point = so2.act(Eigen::Vector2d(1,1));
 

--- a/test/so2/gtest_so2_map.cpp
+++ b/test/so2/gtest_so2_map.cpp
@@ -152,10 +152,10 @@ TEST(TEST_SO2, TEST_SO2_MAP_INVERSE)
   EXPECT_DOUBLE_EQ(1, so2_inv.real());
   EXPECT_DOUBLE_EQ(0, so2_inv.imag());
 
-  so2 = SO2d(M_PI);
+  so2 = SO2d(MANIF_PI);
   so2_inv = so2.inverse();
 
-  EXPECT_DOUBLE_EQ(-M_PI, so2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_inv.angle());
 
   double data_inv[2] = {1,0};
   Eigen::Map<SO2d> so2_inv_map(data_inv);
@@ -167,221 +167,221 @@ TEST(TEST_SO2, TEST_SO2_MAP_INVERSE)
   EXPECT_DOUBLE_EQ(1, so2_inv_map.real());
   EXPECT_DOUBLE_EQ(0, so2_inv_map.imag());
 
-  so2 = SO2d(M_PI);
+  so2 = SO2d(MANIF_PI);
   so2_inv_map = so2.inverse();
 
-  EXPECT_DOUBLE_EQ(-M_PI, so2_inv_map.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_inv_map.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_RPLUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
-  SO2Tangentd so2b(M_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   double datac[2] = {1,0};
   Eigen::Map<SO2d> so2c(datac);
   so2c = so2a.rplus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_LPLUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
-  SO2Tangentd so2b(M_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   double datac[2] = {1,0};
   Eigen::Map<SO2d> so2c(datac);
 
   so2c = so2a.lplus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_PLUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
-  SO2Tangentd so2b(M_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   auto so2c = so2a.plus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_OP_PLUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
-  SO2Tangentd so2b(M_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   auto so2c = so2a + so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_OP_PLUS_EQ)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
-  SO2Tangentd so2b(M_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   so2a += so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2a.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_RMINUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI);
+  so2a = SO2d(MANIF_PI);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   auto so2c = so2a.rminus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_LMINUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI);
+  so2a = SO2d(MANIF_PI);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   auto so2c = so2a.lminus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_MINUS)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI);
+  so2a = SO2d(MANIF_PI);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   auto so2c = so2a.minus(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_LIFT)
 {
   double data[2] = {1,0};
   Eigen::Map<SO2d> so2(data);
-  so2 = SO2d(M_PI);
+  so2 = SO2d(MANIF_PI);
 
   auto so2_log = so2.log();
 
   static_assert(std::is_same<SO2d::Tangent, decltype(so2_log)>::value, "");
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_log.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_COMPOSE)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   double datac[2] = {1,0};
   Eigen::Map<SO2d> so2c(datac);
 
   so2c = so2a.compose(so2b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
-  SO2d so2d(M_PI_2);
+  SO2d so2d(MANIF_PI_2);
 
   auto so2e = so2a.compose(so2d);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2e.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2e.angle());
 
-  SO2d so2f(M_PI_2);
+  SO2d so2f(MANIF_PI_2);
 
   auto so2g = so2f.compose(so2a);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2g.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2g.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_OP_COMPOSE)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   double datac[2] = {1,0};
   Eigen::Map<SO2d> so2c(datac);
 
   so2c = so2a * so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
-  SO2d so2d(M_PI_2);
+  SO2d so2d(MANIF_PI_2);
 
   auto so2e = so2a * so2d;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2e.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2e.angle());
 
-  SO2d so2f(M_PI_2);
+  SO2d so2f(MANIF_PI_2);
 
   auto so2g = so2f * so2a;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2g.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2g.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_MAP_OP_COMPOSE_EQ)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI_2);
+  so2a = SO2d(MANIF_PI_2);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   so2a *= so2b;
 
-  EXPECT_DOUBLE_EQ(M_PI, so2a.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2a.angle());
 
-  SO2d so2d(M_PI_2);
+  SO2d so2d(MANIF_PI_2);
 
   so2a *= so2d;
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2a.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2a.angle());
 
-  SO2d so2f(M_PI_2);
+  SO2d so2f(MANIF_PI_2);
 
   so2f *= so2a;
 
@@ -394,27 +394,27 @@ TEST(TEST_SO2, TEST_SO2_MAP_BETWEEN)
 {
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
-  so2a = SO2d(M_PI);
+  so2a = SO2d(MANIF_PI);
 
   double datab[2] = {1,0};
   Eigen::Map<SO2d> so2b(datab);
-  so2b = SO2d(M_PI_2);
+  so2b = SO2d(MANIF_PI_2);
 
   auto so2c = so2a.between(so2b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2c.angle());
 
-  SO2d so2d(M_PI_2);
+  SO2d so2d(MANIF_PI_2);
 
   auto so2e = so2a.between(so2d);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2e.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2e.angle());
 
-  SO2d so2f(M_PI_2);
+  SO2d so2f(MANIF_PI_2);
 
   auto so2g = so2f.between(so2a);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2g.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2g.angle());
 }
 
 /// with Jacs
@@ -435,10 +435,10 @@ TEST(TEST_SO2, TEST_SO2_MAP_INVERSE_JAC)
   EXPECT_EQ(1, J_inv.cols());
   EXPECT_DOUBLE_EQ(-1, J_inv(0));
 
-  so2.angle(M_PI);
+  so2.angle(MANIF_PI);
   so2.inverse(so2_inv, J_inv);
 
-  EXPECT_DOUBLE_EQ(-M_PI, so2_inv.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_inv.angle());
 
   EXPECT_EQ(1, J_inv.rows());
   EXPECT_EQ(1, J_inv.cols());
@@ -447,14 +447,14 @@ TEST(TEST_SO2, TEST_SO2_MAP_INVERSE_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_LIFT_JAC)
 {
-  SO2d so2(M_PI);
+  SO2d so2(MANIF_PI);
 
   SO2d::Tangent so2_log;
   SO2d::Tangent::Jacobian J_log;
 
   so2.log(so2_log, J_log);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_log.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_log.angle());
 
   /// @todo check this J
   EXPECT_EQ(1, J_log.rows());
@@ -464,15 +464,15 @@ TEST(TEST_SO2, TEST_SO2_MAP_LIFT_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_COMPOSE_JAC)
 {
-  SO2d so2a(M_PI_2);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2d so2b(MANIF_PI_2);
 
   SO2d so2c;
   SO2d::Jacobian J_c_a, J_c_b;
 
   so2a.compose(so2b, so2c, J_c_a, J_c_b);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_c_a.rows());
   EXPECT_EQ(1, J_c_a.cols());
@@ -485,8 +485,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_COMPOSE_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_RPLUS_JAC)
 {
-  SO2d so2a(M_PI_2);
-  SO2Tangentd so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   SO2d so2c;
   SO2d::Jacobian J_rplus_m;
@@ -494,7 +494,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_RPLUS_JAC)
 
   so2a.rplus(so2b, so2c, J_rplus_m, J_rplus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_rplus_m.rows());
   EXPECT_EQ(1, J_rplus_m.cols());
@@ -507,8 +507,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_RPLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_LPLUS_JAC)
 {
-  SO2d so2a(M_PI_2);
-  SO2Tangentd so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   SO2d so2c;
   SO2d::Jacobian J_lplus_t;
@@ -516,7 +516,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_LPLUS_JAC)
 
   so2a.lplus(so2b, so2c, J_lplus_t, J_lplus_m);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_lplus_t.rows());
   EXPECT_EQ(1, J_lplus_t.cols());
@@ -529,8 +529,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_LPLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_PLUS_JAC)
 {
-  SO2d so2a(M_PI_2);
-  SO2Tangentd so2b(M_PI_2);
+  SO2d so2a(MANIF_PI_2);
+  SO2Tangentd so2b(MANIF_PI_2);
 
   SO2d so2c;
   SO2d::Jacobian J_plus_m;
@@ -538,7 +538,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_PLUS_JAC)
 
   so2a.plus(so2b, so2c, J_plus_m, J_plus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_plus_m.rows());
   EXPECT_EQ(1, J_plus_m.cols());
@@ -551,8 +551,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_PLUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_RMINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2Tangentd so2c;
 
@@ -560,7 +560,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_RMINUS_JAC)
 
   so2a.rminus(so2b, so2c, J_rminus_a, J_rminus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_rminus_a.rows());
   EXPECT_EQ(1, J_rminus_a.cols());
@@ -573,8 +573,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_RMINUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_LMINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2Tangentd so2c;
 
@@ -582,7 +582,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_LMINUS_JAC)
 
   so2a.lminus(so2b, so2c, J_lminus_a, J_lminus_b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_lminus_a.rows());
   EXPECT_EQ(1, J_lminus_a.cols());
@@ -595,8 +595,8 @@ TEST(TEST_SO2, TEST_SO2_MAP_LMINUS_JAC)
 
 TEST(TEST_SO2, TEST_SO2_MAP_MINUS_JAC)
 {
-  SO2d so2a(M_PI);
-  SO2d so2b(M_PI_2);
+  SO2d so2a(MANIF_PI);
+  SO2d so2b(MANIF_PI_2);
 
   SO2Tangentd so2c;
 
@@ -604,7 +604,7 @@ TEST(TEST_SO2, TEST_SO2_MAP_MINUS_JAC)
 
   so2a.minus(so2b, so2c, J_minus_a, J_minus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so2c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so2c.angle());
 
   EXPECT_EQ(1, J_minus_a.rows());
   EXPECT_EQ(1, J_minus_a.cols());

--- a/test/so2/gtest_so2_tangent.cpp
+++ b/test/so2/gtest_so2_tangent.cpp
@@ -6,23 +6,23 @@ using namespace manif;
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_0)
 {
-  SO2Tangentd so2tan(SO2Tangentd::DataType(M_PI));
+  SO2Tangentd so2tan(SO2Tangentd::DataType(MANIF_PI));
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_1)
 {
-  SO2Tangentd so2tan(M_PI);
+  SO2Tangentd so2tan(MANIF_PI);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_DATA)
 {
-  const SO2Tangentd so2tan(M_PI);
+  const SO2Tangentd so2tan(MANIF_PI);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.coeffs()(0));
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.coeffs()(0));
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_ZERO)
@@ -59,28 +59,28 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_ZERO2)
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_RETRACT)
 {
-  SO2Tangentd so2_tan(M_PI);
+  SO2Tangentd so2_tan(MANIF_PI);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_tan.angle());
 
   auto so2_exp = so2_tan.exp();
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_SKEW)
 {
-  SO2Tangentd so2_tan(M_PI);
+  SO2Tangentd so2_tan(MANIF_PI);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_tan.angle());
 
   SO2Tangentd::LieAlg so2_lie = so2_tan.hat();
 
   EXPECT_DOUBLE_EQ( 0,    so2_lie(0,0));
-  EXPECT_DOUBLE_EQ(-M_PI, so2_lie(0,1));
-  EXPECT_DOUBLE_EQ( M_PI, so2_lie(1,0));
+  EXPECT_DOUBLE_EQ(-MANIF_PI, so2_lie(0,1));
+  EXPECT_DOUBLE_EQ( MANIF_PI, so2_lie(1,0));
   EXPECT_DOUBLE_EQ( 0,    so2_lie(1,1));
 }
 
@@ -88,18 +88,18 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_SKEW)
 
 //TEST(TEST_SO2, TEST_SO2_TANGENT_RETRACT_JAC)
 //{
-//  SO2Tangentd so2_tan(M_PI);
+//  SO2Tangentd so2_tan(MANIF_PI);
 
-//  EXPECT_DOUBLE_EQ(M_PI, so2_tan.angle());
+//  EXPECT_DOUBLE_EQ(MANIF_PI, so2_tan.angle());
 
 //  SO2d so2_exp;
 //  SO2d::Jacobian J_ret;
 
 //  so2_tan.exp(so2_exp, J_ret);
 
-//  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-//  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-//  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+//  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+//  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+//  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
 //  /// @todo check this J
 //  EXPECT_EQ(1, J_ret.rows());
@@ -109,18 +109,18 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_SKEW)
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_RETRACT_OPTJAC)
 {
-  SO2Tangentd so2_tan(M_PI);
+  SO2Tangentd so2_tan(MANIF_PI);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2_tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_tan.angle());
 
   SO2d so2_exp;
   SO2d::Jacobian J_ret;
 
   so2_exp = so2_tan.exp(J_ret);
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo check this J
   EXPECT_EQ(1, J_ret.rows());

--- a/test/so2/gtest_so2_tangent_map.cpp
+++ b/test/so2/gtest_so2_tangent_map.cpp
@@ -6,10 +6,10 @@ using namespace manif;
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_0)
 {
-  double data(M_PI);
+  double data(MANIF_PI);
   Eigen::Map<SO2Tangentd> so2tan(&data);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_DATA)
@@ -17,13 +17,13 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_DATA)
   /// @todo without specifying const
   /// it calls non-const data()
 
-  double data(M_PI);
+  double data(MANIF_PI);
   const Eigen::Map<SO2Tangentd> so2tan(&data);
 
 //  EXPECT_NE(nullptr, so2tan.data());
 //  EXPECT_EQ(&data, so2tan.data()->data());
 
-//  EXPECT_DOUBLE_EQ(M_PI, (*so2tan.data())(0));
+//  EXPECT_DOUBLE_EQ(MANIF_PI, (*so2tan.data())(0));
 }
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_ZERO)
@@ -63,34 +63,34 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_ZERO2)
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_RETRACT)
 {
-  double data(M_PI);
+  double data(MANIF_PI);
   Eigen::Map<SO2Tangentd> so2tan(&data);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   auto so2_exp = so2tan.exp();
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 }
 
 /// with Jacs
 
 TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_RETRACT_JAC)
 {
-  double data(M_PI);
+  double data(MANIF_PI);
   Eigen::Map<SO2Tangentd> so2tan(&data);
 
-  EXPECT_DOUBLE_EQ(M_PI, so2tan.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2tan.angle());
 
   SO2d::Jacobian J_ret;
 
   SO2d so2_exp = so2tan.exp(J_ret);
 
-  EXPECT_DOUBLE_EQ(std::cos(M_PI), so2_exp.real());
-  EXPECT_DOUBLE_EQ(std::sin(M_PI), so2_exp.imag());
-  EXPECT_DOUBLE_EQ(M_PI, so2_exp.angle());
+  EXPECT_DOUBLE_EQ(std::cos(MANIF_PI), so2_exp.real());
+  EXPECT_DOUBLE_EQ(std::sin(MANIF_PI), so2_exp.imag());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so2_exp.angle());
 
   /// @todo check this J
   EXPECT_EQ(1, J_ret.rows());

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -641,7 +641,7 @@ TEST(TEST_SO3, TEST_SO3_RPLUS_JAC)
 
   so3a.rplus(so3b, so3c, J_rplus_m, J_rplus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so3c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so3c.angle());
 
   EXPECT_EQ(1, J_rplus_m.rows());
   EXPECT_EQ(1, J_rplus_m.cols());
@@ -663,7 +663,7 @@ TEST(TEST_SO3, TEST_SO3_LPLUS_JAC)
 
   so3a.lplus(so3b, so3c, J_lplus_t, J_lplus_m);
 
-  EXPECT_DOUBLE_EQ(M_PI, so3c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so3c.angle());
 
   EXPECT_EQ(1, J_lplus_t.rows());
   EXPECT_EQ(1, J_lplus_t.cols());
@@ -685,7 +685,7 @@ TEST(TEST_SO3, TEST_SO3_PLUS_JAC)
 
   so3a.plus(so3b, so3c, J_plus_m, J_plus_t);
 
-  EXPECT_DOUBLE_EQ(M_PI, so3c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI, so3c.angle());
 
   EXPECT_EQ(1, J_plus_m.rows());
   EXPECT_EQ(1, J_plus_m.cols());
@@ -698,8 +698,8 @@ TEST(TEST_SO3, TEST_SO3_PLUS_JAC)
 
 TEST(TEST_SO3, TEST_SO3_RMINUS_JAC)
 {
-  SO3d so3a(M_PI);
-  SO3d so3b(M_PI_2);
+  SO3d so3a(MANIF_PI);
+  SO3d so3b(MANIF_PI_2);
 
   SO3Tangentd so3c;
 
@@ -707,7 +707,7 @@ TEST(TEST_SO3, TEST_SO3_RMINUS_JAC)
 
   so3a.rminus(so3b, so3c, J_rminus_a, J_rminus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so3c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so3c.angle());
 
   EXPECT_EQ(1, J_rminus_a.rows());
   EXPECT_EQ(1, J_rminus_a.cols());
@@ -720,8 +720,8 @@ TEST(TEST_SO3, TEST_SO3_RMINUS_JAC)
 
 TEST(TEST_SO3, TEST_SO3_LMINUS_JAC)
 {
-  SO3d so3a(M_PI);
-  SO3d so3b(M_PI_2);
+  SO3d so3a(MANIF_PI);
+  SO3d so3b(MANIF_PI_2);
 
   SO3Tangentd so3c;
 
@@ -729,7 +729,7 @@ TEST(TEST_SO3, TEST_SO3_LMINUS_JAC)
 
   so3a.lminus(so3b, so3c, J_lminus_a, J_lminus_b);
 
-  EXPECT_DOUBLE_EQ(-M_PI_2, so3c.angle());
+  EXPECT_DOUBLE_EQ(-MANIF_PI_2, so3c.angle());
 
   EXPECT_EQ(1, J_lminus_a.rows());
   EXPECT_EQ(1, J_lminus_a.cols());
@@ -742,8 +742,8 @@ TEST(TEST_SO3, TEST_SO3_LMINUS_JAC)
 
 TEST(TEST_SO3, TEST_SO3_MINUS_JAC)
 {
-  SO3d so3a(M_PI);
-  SO3d so3b(M_PI_2);
+  SO3d so3a(MANIF_PI);
+  SO3d so3b(MANIF_PI_2);
 
   SO3Tangentd so3c;
 
@@ -751,7 +751,7 @@ TEST(TEST_SO3, TEST_SO3_MINUS_JAC)
 
   so3a.minus(so3b, so3c, J_minus_a, J_minus_b);
 
-  EXPECT_DOUBLE_EQ(M_PI_2, so3c.angle());
+  EXPECT_DOUBLE_EQ(MANIF_PI_2, so3c.angle());
 
   EXPECT_EQ(1, J_minus_a.rows());
   EXPECT_EQ(1, J_minus_a.cols());
@@ -846,7 +846,7 @@ TEST(TEST_SO3, TEST_SO3_ACT)
   EXPECT_NEAR(+1, transformed_point.y(), 1e-15);
   EXPECT_NEAR(+1, transformed_point.z(), 1e-15);
 
-  so3 = SO3d(M_PI, M_PI_2, M_PI/4.);
+  so3 = SO3d(MANIF_PI, MANIF_PI_2, MANIF_PI/4.);
 
   transformed_point = so3.act(Eigen::Vector3d(1,1,1));
 
@@ -854,7 +854,7 @@ TEST(TEST_SO3, TEST_SO3_ACT)
   EXPECT_NEAR(-1.414213562373, transformed_point.y(), 1e-12);
   EXPECT_NEAR(-1, transformed_point.z(), 1e-15);
 
-  so3 = SO3d(M_PI/4, -M_PI_2, -M_PI);
+  so3 = SO3d(MANIF_PI/4, -MANIF_PI_2, -MANIF_PI);
 
   transformed_point = so3.act(Eigen::Vector3d(1,1,1));
 


### PR DESCRIPTION
replace, 
- `M_PI` -> `MANIF_PI`
- `M_PI_2` -> `MANIF_PI_2`
- `M_PI_4` -> `MANIF_PI_4`

The macros `M_PI`* are not part of the cpp standard and are rather a legacy from c. They may not be available on non-unix systems. The best way to overcome the issue is not clear and highly discussed ^^.
This PR essentially re-implement the macros we are using in `manif`, either in the library or in testing.

This is part of the effort to support windows #88.