### PR TITLE
Enforce constructors' arguments correctness

### DIFF
--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -122,8 +122,20 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SE2)
 
 template <typename _Scalar>
+template <typename _EigenDerived>
+SE2<_Scalar>::SE2(const Eigen::MatrixBase<_EigenDerived>& data)
+  : data_(data)
+{
+  using std::abs;
+  MANIF_CHECK(abs(data_.template tail<2>().norm()-Scalar(1)) <
+              Constants<Scalar>::eps_s,
+              "SE2 constructor argument not normalized !",
+              invalid_argument);
+}
+
+template <typename _Scalar>
 SE2<_Scalar>::SE2(const Base& o)
-  : data_(o.coeffs())
+  : SE2(o.coeffs())
 {
   //
 }
@@ -132,7 +144,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SE2<_Scalar>::SE2(
     const SE2Base<_DerivedOther>& o)
-  : data_(o.coeffs())
+  : SE2(o.coeffs())
 {
   //
 }
@@ -141,15 +153,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SE2<_Scalar>::SE2(
     const LieGroupBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE2<_Scalar>::SE2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
+  : SE2(o.coeffs())
 {
   //
 }

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -80,14 +80,41 @@ public:
   SE2(const Eigen::MatrixBase<_EigenDerived>& data);
 
   /**
-   * @brief Constructor given a translation and a complex number.
+   * @brief Constructor given a translation and a unit complex number.
    * @param[in] t A translation vector.
    * @param[in] c A complex number.
+   * @throws manif::invalid_argument on un-normalized complex number.
    */
   SE2(const Translation& t, const std::complex<Scalar>& c);
 
+  /**
+   * @brief Constructor given the x and y components of the translational part
+   * and an angle.
+   * @param[in] x The x-components of the translational part.
+   * @param[in] y The y-components of the translational part.
+   * @param[in] c An angle.
+   */
   SE2(const Scalar x, const Scalar y, const Scalar theta);
+
+  /**
+   * @brief Constructor given the x and y components of the translational part
+   * and the real and imaginary part of a unit complex number.
+   * @param[in] x The x-components of the translational part.
+   * @param[in] y The y-components of the translational part.
+   * @param[in] real The real of a unitary complex number.
+   * @param[in] imag The imaginary of a unitary complex number.
+   * @throws manif::invalid_argument on un-normalized complex number.
+   */
   SE2(const Scalar x, const Scalar y, const Scalar real, const Scalar imag);
+
+  /**
+   * @brief Constructor given the x and y components of the translational part
+   * and the real and imaginary part of a unit complex number.
+   * @param[in] x The x-components of the translational part.
+   * @param[in] y The y-components of the translational part.
+   * @param[in] c The unitary complex number.
+   * @throws manif::invalid_argument on un-normalized complex number.
+   */
   SE2(const Scalar x, const Scalar y, const std::complex<Scalar>& c);
 
   /**

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -61,6 +61,7 @@ public:
   MANIF_COMPLETE_GROUP_TYPEDEF
   using Translation = typename Base::Translation;
   MANIF_INHERIT_GROUP_API
+  using Base::normalize;
 
   SE2()  = default;
   ~SE2() = default;

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -323,7 +323,7 @@ struct GeneratorEvaluator<SE2TangentBase<Derived>>
         return E2;
       }
       default:
-        MANIF_THROW("Index i must be in [0,2]!");
+        MANIF_THROW("Index i must be in [0,2]!", invalid_argument);
         break;
     }
 

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -144,6 +144,15 @@ public:
    * @brief Get the y component of the translational part.
    */
   Scalar y() const;
+
+  /**
+   * @brief Normalize the underlying complex number.
+   */
+  void normalize();
+
+protected:
+
+  using Base::coeffs_nonconst;
 };
 
 template <typename _Derived>
@@ -357,6 +366,12 @@ typename SE2Base<_Derived>::Scalar
 SE2Base<_Derived>::y() const
 {
   return coeffs().y();
+}
+
+template <typename _Derived>
+void SE2Base<_Derived>::normalize()
+{
+  coeffs_nonconst().template tails<2>().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -149,8 +149,20 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SE3)
 
 template <typename _Scalar>
+template <typename _EigenDerived>
+SE3<_Scalar>::SE3(const Eigen::MatrixBase<_EigenDerived>& data)
+  : data_(data)
+{
+  using std::abs;
+  MANIF_CHECK(abs(data_.template tail<4>().norm()-Scalar(1)) <
+              Constants<Scalar>::eps_s,
+              "SE3 constructor argument not normalized !",
+              invalid_argument);
+}
+
+template <typename _Scalar>
 SE3<_Scalar>::SE3(const Base& o)
-  : data_(o.coeffs())
+  : SE3(o.coeffs())
 {
   //
 }
@@ -159,7 +171,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SE3<_Scalar>::SE3(
     const SE3Base<_DerivedOther>& o)
-  : data_(o.coeffs())
+  : SE3(o.coeffs())
 {
   //
 }
@@ -168,15 +180,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SE3<_Scalar>::SE3(
     const LieGroupBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE3<_Scalar>::SE3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
+  : SE3(o.coeffs())
 {
   //
 }

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -70,6 +70,8 @@ public:
 
   MANIF_INHERIT_GROUP_API
 
+  using Base::normalize;
+
   SE3()  = default;
   ~SE3() = default;
 

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -89,9 +89,10 @@ public:
   SE3(const Eigen::MatrixBase<_EigenDerived>& data);
 
   /**
-   * @brief Constructor given a translation and a quaternion.
+   * @brief Constructor given a translation and a unit quaternion.
    * @param[in] t A translation vector.
-   * @param[in] q A quaternion.
+   * @param[in] q A unit quaternion.
+   * @throws manif::invalid_argument on un-normalized complex number.
    */
   SE3(const Translation& t,
       const Eigen::Quaternion<Scalar>& q);
@@ -99,7 +100,7 @@ public:
   /**
    * @brief Constructor given a translation and an angle axis.
    * @param[in] t A translation vector.
-   * @param[in] q A quaternion.
+   * @param[in] angle_axis An angle-axis.
    */
   SE3(const Translation& t,
       const Eigen::AngleAxis<Scalar>& angle_axis);

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -418,7 +418,7 @@ struct GeneratorEvaluator<SE3TangentBase<Derived>>
         return E5;
       }
       default:
-        MANIF_THROW("Index i must be in [0,5]!");
+        MANIF_THROW("Index i must be in [0,5]!", invalid_argument);
         break;
     }
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -150,6 +150,8 @@ public:
   //Scalar pitch() const;
   //Scalar yaw() const;
 
+  void normalize();
+
 protected:
 
   using Base::coeffs_nonconst;
@@ -351,6 +353,12 @@ typename SE3Base<_Derived>::Scalar
 SE3Base<_Derived>::z() const
 {
   return coeffs().z();
+}
+
+template <typename _Derived>
+void SE3Base<_Derived>::normalize()
+{
+  coeffs_nonconst().template tails<4>().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -150,6 +150,9 @@ public:
   //Scalar pitch() const;
   //Scalar yaw() const;
 
+  /**
+   * @brief Normalize the underlying quaternion.
+   */
   void normalize();
 
 protected:

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -105,8 +105,19 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO2)
 
 template <typename _Scalar>
+template <typename _EigenDerived>
+SO2<_Scalar>::SO2(const Eigen::MatrixBase<_EigenDerived>& data)
+  : data_(data)
+{
+  using std::abs;
+  MANIF_CHECK(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+              "SO2 constructor argument not normalized !",
+              invalid_argument);
+}
+
+template <typename _Scalar>
 SO2<_Scalar>::SO2(const Base& o)
-  : data_(o.coeffs())
+  : SO2(o.coeffs())
 {
   //
 }
@@ -115,7 +126,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SO2<_Scalar>::SO2(
     const SO2Base<_DerivedOther>& o)
-  : data_(o.coeffs())
+  : SO2(o.coeffs())
 {
   //
 }
@@ -124,15 +135,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SO2<_Scalar>::SO2(
     const LieGroupBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO2<_Scalar>::SO2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
+  : SO2(o.coeffs())
 {
   //
 }

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -80,6 +80,9 @@ public:
   /**
    * @brief Constructor given the real and imaginary part
    * of a unit complex number representing the angle.
+   * @param[in] real The real of a unitary complex number.
+   * @param[in] imag The imaginary of a unitary complex number.
+   * @throws manif::invalid_argument on un-normalized complex number.
    */
   SO2(const Scalar real, const Scalar imag);
 

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -59,6 +59,7 @@ public:
 
   MANIF_COMPLETE_GROUP_TYPEDEF
   MANIF_INHERIT_GROUP_API
+  using Base::normalize;
 
   SO2()  = default;
   ~SO2() = default;

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -200,7 +200,8 @@ struct GeneratorEvaluator<SO2TangentBase<Derived>>
   run(const int i)
   {
     MANIF_CHECK(i==0 && i<SO2TangentBase<Derived>::DoF,
-                "Index i must be 0!");
+                "Index i must be 0!",
+                invalid_argument);
 
     const static typename SO2TangentBase<Derived>::LieAlg E0 =
         skew(typename SO2TangentBase<Derived>::Scalar(1));

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -124,6 +124,11 @@ public:
    */
   Scalar angle() const;
 
+  /**
+   * @brief Normalize the underlying complex number.
+   */
+  void normalize();
+
 protected:
 
   using Base::coeffs_nonconst;
@@ -282,6 +287,12 @@ SO2Base<_Derived>::angle() const
 //{
 //  return coeffs.y();
 //}
+
+template <typename _Derived>
+void SO2Base<_Derived>::normalize()
+{
+  coeffs_nonconst().normalize();
+}
 
 namespace internal {
 

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -82,12 +82,19 @@ public:
   SO3(const Eigen::MatrixBase<_EigenDerived>& data);
 
   /**
-   * @brief Constructor given a quaternion.
+   * @brief Constructor given a unit quaternion.
+   * @param[in] q A unit quaternion.
+   * @throws manif::invalid_argument on un-normalized quaternion.
    */
   SO3(const QuaternionDataType& q);
 
   /**
    * @brief Constructor given the quaternion's coefficients.
+   * @param[in] x The x-components of a unit quaternion.
+   * @param[in] y The x-components of a unit quaternion.
+   * @param[in] z The x-components of a unit quaternion.
+   * @param[in] w The x-components of a unit quaternion.
+   * @throws manif::invalid_argument on un-normalized quaternion.
    */
   SO3(const Scalar x, const Scalar y,
       const Scalar z, const Scalar w);

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -115,8 +115,19 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO3)
 
 template <typename _Scalar>
+template <typename _EigenDerived>
+SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
+  : data_(data)
+{
+  using std::abs;
+  MANIF_CHECK(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+              "SO3 constructor argument not normalized !",
+              invalid_argument);
+}
+
+template <typename _Scalar>
 SO3<_Scalar>::SO3(const Base& o)
-  : data_(o.coeffs())
+  : SO3(o.coeffs())
 {
   //
 }
@@ -125,7 +136,7 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SO3<_Scalar>::SO3(
     const SO3Base<_DerivedOther>& o)
-  : data_(o.coeffs())
+  : SO3(o.coeffs())
 {
   //
 }
@@ -134,22 +145,16 @@ template <typename _Scalar>
 template <typename _DerivedOther>
 SO3<_Scalar>::SO3(
     const LieGroupBase<_DerivedOther>& o)
-  : data_(o.coeffs())
+  : SO3(o.coeffs())
 {
   //
 }
 
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  //
-}
+
 
 template <typename _Scalar>
 SO3<_Scalar>::SO3(const QuaternionDataType& q)
-  : data_(q.coeffs())
+  : SO3(q.coeffs())
 {
   //
 }
@@ -157,7 +162,7 @@ SO3<_Scalar>::SO3(const QuaternionDataType& q)
 template <typename _Scalar>
 SO3<_Scalar>::SO3(const Scalar x, const Scalar y,
                   const Scalar z, const Scalar w)
-  : data_(x, y, z, w)
+  : SO3((DataType() << x, y, z, w).finished())
 {
   //
 }

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -63,6 +63,7 @@ public:
   MANIF_INHERIT_GROUP_API
 
   using Base::quat;
+  using Base::normalize;
 
   SO3()  = default;
   ~SO3() = default;

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -286,7 +286,7 @@ struct GeneratorEvaluator<SO3TangentBase<Derived>>
         return E2;
       }
       default:
-        MANIF_THROW("Index i must be in [0,2]!");
+        MANIF_THROW("Index i must be in [0,2]!", invalid_argument);
         break;
     }
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -120,6 +120,9 @@ public:
   //! @brief Get quaternion.
   QuaternionDataType quat() const;
 
+  /**
+   * @brief Normalize the underlying quaternion.
+   */
   void normalize();
 
 protected:

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -120,11 +120,11 @@ public:
   //! @brief Get quaternion.
   QuaternionDataType quat() const;
 
+  void normalize();
+
 protected:
 
   using Base::coeffs_nonconst;
-
-  void normalize();
 };
 
 template <typename _Derived>
@@ -332,7 +332,7 @@ SO3Base<_Derived>::quat() const
 template <typename _Derived>
 void SO3Base<_Derived>::normalize()
 {
-  coeffs().normalize();
+  coeffs_nonconst().normalize();
 }
 
 namespace internal {

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -446,8 +446,8 @@ public:
 
   void evalGeneratorsHat()
   {
-    EXPECT_THROW(Tangent::Generator(-1), std::runtime_error);
-    EXPECT_THROW(Tangent::Generator(42), std::runtime_error);
+    EXPECT_THROW(Tangent::Generator(-1), manif::invalid_argument);
+    EXPECT_THROW(Tangent::Generator(42), manif::invalid_argument);
 
     typename Tangent::LieAlg sum_delta_hat;
     sum_delta_hat.setZero();

--- a/test/se2/gtest_se2.cpp
+++ b/test/se2/gtest_se2.cpp
@@ -74,7 +74,10 @@ TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_ISO)
 
 TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_COPY)
 {
-  SE2d se2(SE2d(4, 2, 1,1));
+  using std::cos;
+  using std::sin;
+
+  SE2d se2(SE2d(4, 2, cos(M_PI/4.), sin(M_PI/4.)));
 
   EXPECT_DOUBLE_EQ(4, se2.x());
   EXPECT_DOUBLE_EQ(2, se2.y());

--- a/test/se2/gtest_se2.cpp
+++ b/test/se2/gtest_se2.cpp
@@ -84,6 +84,25 @@ TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(MANIF_PI/4., se2.angle());
 }
 
+TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SE2d se2(SE2d(4, 2, 1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SE2d se2(SE2d::DataType(4, 2, 1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SE2d se2(SE2d::DataType(4, 2, 1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SE2, TEST_SE2_COEFFS)
 {
   SE2d se2(4, 2, 0);

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -82,6 +82,27 @@ TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(1, se3.coeffs()(6));
 }
 
+TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  // EXPECT_THROW(
+  //   SE3d se3(SE3d(1, 1)),
+  //   manif::invalid_argument
+  // );
+
+  SE3d::DataType values; values << 0,0,0, 1,1,1,1;
+
+  EXPECT_THROW(
+    SE3d se3(values),
+    manif::invalid_argument
+  );
+
+  try {
+    SE3d se3(values);
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SE3, TEST_SE3_DATA)
 {
   SE3d::DataType values; values << 0,0,0, 0,0,0,1;

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -34,7 +34,10 @@ TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_THETA)
 
 TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_COPY)
 {
-  SO2d so2(SO2d(1,1));
+  using std::cos;
+  using std::sin;
+
+  SO2d so2(SO2d(cos(M_PI/4.), sin(M_PI/4.)));
 
   EXPECT_DOUBLE_EQ(MANIF_PI/4., so2.angle());
 }

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -42,6 +42,25 @@ TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(MANIF_PI/4., so2.angle());
 }
 
+TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SO2d so2(SO2d(1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SO2d so2(SO2d::DataType(1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SO2d so2(SO2d::DataType(1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SO2, TEST_SO2_COEFFS)
 {
   SO2d so2(0);

--- a/test/so2/gtest_so2_map.cpp
+++ b/test/so2/gtest_so2_map.cpp
@@ -50,6 +50,9 @@ TEST(TEST_SO2, TEST_SO2_MAP_DATA)
 
 TEST(TEST_SO2, TEST_SO2_MAP_ASSIGN_OP)
 {
+  using std::cos;
+  using std::sin;
+
   double dataa[2] = {1,0};
   Eigen::Map<SO2d> so2a(dataa);
 
@@ -61,10 +64,10 @@ TEST(TEST_SO2, TEST_SO2_MAP_ASSIGN_OP)
   EXPECT_DOUBLE_EQ(0, so2a.real());
   EXPECT_DOUBLE_EQ(1, so2a.imag());
 
-  so2a = SO2d(1, 1);
+  so2a = SO2d(cos(M_PI/4.), sin(M_PI/4.));
 
-  EXPECT_DOUBLE_EQ(1, so2a.real());
-  EXPECT_DOUBLE_EQ(1, so2a.imag());
+  EXPECT_DOUBLE_EQ(cos(M_PI/4.), so2a.real());
+  EXPECT_DOUBLE_EQ(sin(M_PI/4.), so2a.imag());
 
 //  SO2d so2e = so2a;
 

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -56,6 +56,25 @@ TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_ROLL_PITCH_YAW)
   EXPECT_DOUBLE_EQ(1, so3.w());
 }
 
+TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SO3d so3(SO3d(1, 1, 1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SO3d so3(SO3d::DataType(1, 1, 1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SO3d so3(SO3d::DataType(1, 1, 1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SO3, TEST_SO3_IDENTITY)
 {
   SO3d so3;


### PR DESCRIPTION
Replaces #72.

- add custom exception types
- re-organize constructors to have a single entry-point
- enforce normalized complex-numbers/quaternions at construction
- test previous bullet point
- small test fixes

This PR enforces that the rotational-related arguments passed to a constructor resolves in normalized complex-numbers/quaternions ( `norm()-1 < small_eps` )

In case the input arguments are **not** normalized, the function throws an exception of type `manif::invalid_argument`. 
Note that custom types allows for a finer granularity in try/catch blocks.