### PR TITLE
Address #94: Add test for norm stability

### DIFF
--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -648,6 +648,21 @@ TEST(TEST_SO3, TEST_SO3_RIGHT_LEFT_JAC)
   EXPECT_EIGEN_NEAR(tan.rjac(), tan.ljac().transpose());
 }
 
+TEST(TEST_SO3, TEST_SO3_NORM_STABILITY)
+{
+    // Identity
+   manif::SO3d R = manif::SO3d(0, 0, 0, 1.0);
+
+   // Some angular velocity
+   manif::SO3Tangentd Om = Eigen::Vector3d(0.001, 0.0, 0.0);
+
+   // New orientation
+   for (int i = 0 ; i < 1000; i++) {
+      R = R.plus(Om);
+      std::cout << "iteration " << i << ": deviation from unit squaredNorm: " << R.coeffs().squaredNorm() - 1.0 << std::endl;
+   }
+}
+
 /*
 TEST(TEST_SO3, TEST_SO3_RPLUS_JAC)
 {


### PR DESCRIPTION
See #94 

Repeated exp and compose bring the quaternion out of unit norm. This is a numerical issue, and it is normal.

The thing is maybe we are being too strict in the `SO3` constructor and when the squaredNorm of the quaternion is off by more than 1e-15 (`Constants::eps_s`) we throw.

A suggestion is to relax the threshold to some 1e-10 --> use `Constants::eps` instead.