### PR TITLE
Fix numerical instability in composition

### DIFF
--- a/include/manif/SO2.h
+++ b/include/manif/SO2.h
@@ -2,6 +2,7 @@
 #define _MANIF_SO2_H_
 
 #include "manif/impl/macro.h"
+#include "manif/impl/utils.h"
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/tangent_base.h"
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -248,6 +248,8 @@ SO3Base<_Derived>::compose(
     OptJacobianRef J_mc_ma,
     OptJacobianRef J_mc_mb) const
 {
+  using std::abs;
+
   static_assert(
     std::is_base_of<SO3Base<_DerivedOther>, _DerivedOther>::value,
     "Argument does not inherit from S03Base !");
@@ -262,7 +264,17 @@ SO3Base<_Derived>::compose(
   if (J_mc_mb)
     J_mc_mb->setIdentity();
 
-  return LieGroup(quat() * m_SO3.quat());
+  QuaternionDataType ret_q = quat() * m_SO3.quat();
+
+  const Scalar ret_sqnorm = ret_q.squaredNorm();
+
+  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps_s)
+  {
+    const Scalar scale = approxSqrtInv(ret_sqnorm);
+    ret_q.coeffs() *= scale;
+  }
+
+  return LieGroup(ret_q);
 }
 
 template <typename _Derived>

--- a/include/manif/impl/utils.h
+++ b/include/manif/impl/utils.h
@@ -41,6 +41,17 @@ constexpr T toDeg(const T rad)
   return rad * Constants<T>::to_deg;
 }
 
+/**
+ * @brief Degree 2 polynomial approximation of 1/sqrt(x) (reciprocal sqrt).
+ * @param[in] x
+ * @return ~1/sqrt(x)
+ */
+template <typename T>
+constexpr T approxSqrtInv(const T x)
+{
+  return (T(15) / T(8)) - (T(5) / T(4)) * x + (T(3) / T(8)) * x * x;
+}
+
 } /* namespace manif */
 
 #endif /* _MANIF_MANIF_UTILS_H_ */

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -62,7 +62,9 @@
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_STREAM_OP)           \
   { evalStreamOp(); }                                                     \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_INNER)               \
-  { evalInner(); }
+  { evalInner(); }                                                        \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_NUMERICAL_STABILITY) \
+  { evalNumericalStability(); }
 
 #define MANIF_TEST_JACOBIANS(manifold)                                            \
   using TEST_##manifold##_JACOBIANS_TESTER = JacobianTester<manifold>;            \
@@ -495,6 +497,16 @@ public:
 
     EXPECT_DOUBLE_EQ(delta.squaredWeightedNorm(), delta.inner(delta));
     EXPECT_DOUBLE_EQ(delta.inner(delta_other), delta_other.inner(delta));
+  }
+
+  void evalNumericalStability()
+  {
+    unsigned int i = 0;
+    EXPECT_NO_THROW(
+      for (; i < 10000; ++i) {
+        state += Tangent::Random();
+      }
+    ) << "+= failed at iteration " << i ;
   }
 
 protected:


### PR DESCRIPTION
In `compose`, check for numerical drift in complex/quaternion norm and normalize if necessary.

Use an approximation of `1/sqrt(x)` at `x=1` (see [here](https://github.com/artivis/manif/compare/fix/numerical_stability?expand=1#diff-8bde907ebb733ec2326c6d4fde67db7aR50)) to avoid 'expensive' `sqrt` call.

Fix #94.
Replace #95.