### PR TITLE
Fix wrong type deduction in test

### DIFF
--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -476,10 +476,10 @@ TEST(TEST_SO3, TEST_SO3_BETWEEN)
 
   auto so3c = so3a.between(so3b);
 
-  EXPECT_DOUBLE_EQ(0, so3c.x());
-  EXPECT_DOUBLE_EQ(0, so3c.y());
-  EXPECT_DOUBLE_EQ(0, so3c.z());
-  EXPECT_DOUBLE_EQ(1, so3c.w());
+  EXPECT_NEAR(0, so3c.x(), 1e-15);
+  EXPECT_NEAR(0, so3c.y(), 1e-15);
+  EXPECT_NEAR(0, so3c.z(), 1e-15);
+  EXPECT_NEAR(1, so3c.w(), 1e-15);
 }
 
 /// with Jacs
@@ -792,10 +792,10 @@ TEST(TEST_SO3, TEST_SO3_BETWEEN_JAC)
 
   SO3d so3c = so3a.between(so3b, J_between_a, J_between_b);
 
-  EXPECT_DOUBLE_EQ(0, so3c.x());
-  EXPECT_DOUBLE_EQ(0, so3c.y());
-  EXPECT_DOUBLE_EQ(0, so3c.z());
-  EXPECT_DOUBLE_EQ(1, so3c.w());
+  EXPECT_NEAR(0, so3c.x(), 1e-15);
+  EXPECT_NEAR(0, so3c.y(), 1e-15);
+  EXPECT_NEAR(0, so3c.z(), 1e-15);
+  EXPECT_NEAR(1, so3c.w(), 1e-15);
 
   EXPECT_EQ(3, J_between_a.rows());
   EXPECT_EQ(3, J_between_a.cols());

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -429,8 +429,8 @@ TEST(TEST_SO3, TEST_SO3_LIFT)
 TEST(TEST_SO3, TEST_SO3_COMPOSE)
 {
     // compose two particular elements giving identity as result
-  SO3d so3a(toRad(-165),toRad(-135),toRad(-90));
-  SO3d so3b(toRad(15),toRad(45),toRad(90));
+  SO3d so3a(toRad(-165.),toRad(-135.),toRad(-90.));
+  SO3d so3b(toRad(15.),toRad(45.),toRad(90.));
 
   auto so3c = so3a.compose(so3b);
 
@@ -443,8 +443,8 @@ TEST(TEST_SO3, TEST_SO3_COMPOSE)
 TEST(TEST_SO3, TEST_SO3_OP_COMPOSE)
 {
     // compose two particular elements giving identity as result
-  SO3d so3a(toRad(-165),toRad(-135),toRad(-90));
-  SO3d so3b(toRad(15),toRad(45),toRad(90));
+  SO3d so3a(toRad(-165.),toRad(-135.),toRad(-90.));
+  SO3d so3b(toRad(15.),toRad(45.),toRad(90.));
 
   auto so3c = so3a * so3b;
 
@@ -457,8 +457,8 @@ TEST(TEST_SO3, TEST_SO3_OP_COMPOSE)
 TEST(TEST_SO3, TEST_SO3_OP_COMPOSE_EQ)
 {
     // compose two particular elements giving identity as result
-  SO3d so3a(toRad(-165),toRad(-135),toRad(-90));
-  SO3d so3b(toRad(15),toRad(45),toRad(90));
+  SO3d so3a(toRad(-165.),toRad(-135.),toRad(-90.));
+  SO3d so3b(toRad(15.),toRad(45.),toRad(90.));
 
   so3a *= so3b;
 
@@ -471,8 +471,8 @@ TEST(TEST_SO3, TEST_SO3_OP_COMPOSE_EQ)
 TEST(TEST_SO3, TEST_SO3_BETWEEN)
 {
     // between two equals is identity
-  SO3d so3b(toRad(15),toRad(45),toRad(90));
-  SO3d so3a(toRad(-15),toRad(-45),toRad(-90));
+  SO3d so3b(toRad(15.),toRad(45.),toRad(90.));
+  SO3d so3a(toRad(-15.),toRad(-45.),toRad(-90.));
 
   auto so3c = so3a.between(so3b);
 
@@ -559,8 +559,8 @@ TEST(TEST_SO3, TEST_SO3_COMPOSE_JAC)
     // Composing these two elements a*b gives the identity;
     // Jac_a is rotation 'b' transpose;
     // Jac_b is identity
-  SO3d so3a(toRad(-165),toRad(-135),toRad(-90));
-  SO3d so3b(toRad(15),  toRad(45),  toRad(90));
+  SO3d so3a(toRad(-165.),toRad(-135.),toRad(-90.));
+  SO3d so3b(toRad(15.),  toRad(45.),  toRad(90.));
 
   SO3d::Jacobian J_c_a, J_c_b;
 
@@ -785,8 +785,8 @@ TEST(TEST_SO3, TEST_SO3_MINUS_JAC)
 
 TEST(TEST_SO3, TEST_SO3_BETWEEN_JAC)
 {
-  SO3d so3b(toRad(15),toRad(45),toRad(90));
-  SO3d so3a(toRad(-15),toRad(-45),toRad(-90));
+  SO3d so3b(toRad(15.),toRad(45.),toRad(90.));
+  SO3d so3a(toRad(-15.),toRad(-45.),toRad(-90.));
 
   SO3d::Jacobian J_between_a, J_between_b;
 


### PR DESCRIPTION
The function `toRad` is template en deduces the input argument type. In a bunch of so3 tests it deduces type `int` which in turn leads to severe precision loss.  
Fixing the type deduction uncovered some handcrafted failing so3 tests. Not sure yet if those tests are simply wrong or else if there is an actual bug to fix.

The tests need to be fixed before merging this.