### PR TITLE
faster implementation of SO3 random

### DIFF
--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -374,28 +374,42 @@ struct RandomEvaluatorImpl<SE3Base<Derived>>
   static void run(T& m)
   {
     // @note:
+    // We are using:
+    // http://mathworld.wolfram.com/HyperspherePointPicking.html
+    // which is faster than Quaternion::UnitRandom, and also,
     // Quaternion::UnitRandom is not available in Eigen 3.3-beta1
     // which is the default version in Ubuntu 16.04
-    // So we copy its implementation here.
 
     using std::sqrt;
-    using std::sin;
-    using std::cos;
-
-    using Scalar      = typename SE3Base<Derived>::Scalar;
+    using Scalar = typename SO3Base<Derived>::Scalar;
     using Translation = typename SE3Base<Derived>::Translation;
-    using Quaternion  = typename SE3Base<Derived>::QuaternionDataType;
+    using Quaternion = typename SO3Base<Derived>::QuaternionDataType;
 
-    const Scalar u1 = Eigen::internal::random<Scalar>(0, 1),
-                 u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI),
-                 u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
-    const Scalar a = sqrt(1. - u1),
-                 b = sqrt(u1);
+    while (true)
+    {
+      const Scalar u1 = Eigen::internal::random<Scalar>(-1, 1),
+            u2 = Eigen::internal::random<Scalar>(-1, 1);
+      if (u1 * u1 + u2 * u2 > 1.0)
+      {
+        continue;
+      }
 
-    m = Derived(Translation::Random(),
-                Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
-
-    //m = Derived(Translation::Random(), Quaternion::UnitRandom());
+      while (true)
+      {
+        const Scalar u3 = Eigen::internal::random<Scalar>(-1, 1),
+              u4 = Eigen::internal::random<Scalar>(-1, 1);
+        if (u3 * u3 + u4 * u4 > 1.0)
+        {
+          continue;
+        }
+        const Scalar zw_factor = sqrt((1 - u1 * u1 - u2 * u2) / (u3 * u3 + u4 * u4));
+        const Scalar z = u3 * zw_factor;
+        const Scalar w = u4 * zw_factor;
+        m = Derived(Translation::Random(), Quaternion(u1, u2, z, w));
+        break;
+      }
+      break;
+    }
   }
 };
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -359,28 +359,42 @@ struct RandomEvaluatorImpl<SO3Base<Derived>>
   template <typename T>
   static void run(T& m)
   {
-
     // @note:
+    // We are using:
+    // http://mathworld.wolfram.com/HyperspherePointPicking.html
+    // which is faster than Quaternion::UnitRandom, and also,
     // Quaternion::UnitRandom is not available in Eigen 3.3-beta1
     // which is the default version in Ubuntu 16.04
-    // So we copy its implementation here.
 
     using std::sqrt;
-    using std::sin;
-    using std::cos;
-
     using Scalar = typename SO3Base<Derived>::Scalar;
     using Quaternion = typename SO3Base<Derived>::QuaternionDataType;
 
-    const Scalar u1 = Eigen::internal::random<Scalar>(0, 1),
-                 u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI),
-                 u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
-    const Scalar a = sqrt(1. - u1),
-                 b = sqrt(u1);
-    m = Derived(Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
+    while (true)
+    {
+      const Scalar u1 = Eigen::internal::random<Scalar>(-1, 1),
+            u2 = Eigen::internal::random<Scalar>(-1, 1);
+      if (u1 * u1 + u2 * u2 > 1.0)
+      {
+        continue;
+      }
 
-
-    // m = Derived(Quaternion::UnitRandom());
+      while (true)
+      {
+        const Scalar u3 = Eigen::internal::random<Scalar>(-1, 1),
+              u4 = Eigen::internal::random<Scalar>(-1, 1);
+        if (u3 * u3 + u4 * u4 > 1.0)
+        {
+          continue;
+        }
+        const Scalar zw_factor = sqrt((1 - u1 * u1 - u2 * u2) / (u3 * u3 + u4 * u4));
+        const Scalar z = u3 * zw_factor;
+        const Scalar w = u4 * zw_factor;
+        m = Derived(Quaternion(u1, u2, z, w));
+        break;
+      }
+      break;
+    }
   }
 };
 


### PR DESCRIPTION
Following my [comment on sophus](https://github.com/strasdat/Sophus/issues/192#issuecomment-533065151) I suspected that [Marsaglia's rejection sampling](http://mathworld.wolfram.com/HyperspherePointPicking.html) is faster than the more elegant method that is currently being used.

So I implemented this method.

Below are some benchmarks. Please check out my branch and test on your machine and see if your experience matches mine. It seems we can get about 20% more performance.

I am confused why the same code for generating a random quaternion is duplicated in `SE3_base.h` and in `SO3_base.h`. If anyone has ideas for refactoring it so that it is no longer duplicated, I will be happy to hear.

## Benchmarks:

Benchmark code:

```c++
#include <Eigen/Dense>
#include <chrono>
#include <fstream>
#include <iostream>
#include <vector>

#include "manif/SO3.h"

int main() {
    std::ofstream fout("so3_randomization.txt");
    const auto tic = std::chrono::steady_clock::now();
    const size_t n = 20'000'000;
    std::vector<manif::SO3d, Eigen::aligned_allocator<manif::SO3d>> stuff;
    stuff.reserve(n);
    for (size_t i = 0; i < n; i++) {
        stuff.push_back(manif::SO3d::Random());
    }
    const auto toc = std::chrono::steady_clock::now();
    std::cout << "Time elapsed: "
              << std::chrono::duration<double>(toc - tic).count() << " s"
              << std::endl;

    for (const auto &zxcv : stuff) {
        fout << zxcv.w() << ", " << zxcv.x() << ", " << zxcv.y() << ", "
             << zxcv.z() << std::endl;
    }
    return 0;
}

```

| compiler | manif branch | result (seconds) |
| - | - | - |
| `clang++ -O3 -I../manif/include -I/usr/include/eigen3 -I../manif/external/lt -o test test.cpp` | devel | 1.62653 |
| `clang++ -O3 -I../manif/include -I/usr/include/eigen3 -I../manif/external/lt -o test test.cpp` | dllu/faster-so3-random | 1.0261 |
| `g++ -O3 -I../manif/include -I/usr/include/eigen3 -I../manif/external/lt -o test test.cpp` | devel | 1.46156 |
| `g++ -O3 -I../manif/include -I/usr/include/eigen3 -I../manif/external/lt -o test test.cpp` | dllu/faster-so3-random | 1.22057 |

## Compilers used:

```
manif-test » clang++ --version
clang version 10.0.0 (/startdir/llvm-project-git bfb5b0cb86cf90d9fa794f873644aa642b652c43)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
manif-test » g++ --version
g++ (GCC) 9.1.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Test System

* AMD Ryzen 9 3900X 12-Core Processor
* Arch Linux with kernel version Linux 5.2.0-rc1-amd-staging-drm-next-git-b8cd95e15410+

## Randomness tests

I used a variant of qqiu's MATLAB script.

```matlab
clear; clc; close all;
qua = dlmread('so3_randomization.txt')(1:200000,:);
axang_arr = quat2axang(qua);
figure(1)
plot3(axang_arr(:,1), axang_arr(:,2), axang_arr(:,3), '.');
figure(2)
hist(axang_arr(:,4),100); 

qua = dlmread('so3_randomization_new.txt')(1:200000,:);
axang_arr = quat2axang(qua);
figure(3)
plot3(axang_arr(:,1), axang_arr(:,2), axang_arr(:,3), '.');
figure(4)
hist(axang_arr(:,4),100); 
```

Because I am using a different `quat2axang` implementation, mine outputs angle in [0, 2pi] rather than [-pi, pi] like @qqfly 's. But it does not make a difference.

![pic](https://pics.dllu.net/file/dllu-sc/K9pVnOVvA0kubucM.png)

Top: devel branch; bottom: my branch. Results look identical.