### PR TITLE
Enable arm64 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -281,6 +281,19 @@ matrix:
       - make test
 
   #
+  # ARM64
+  #
+  - os: linux
+    env:
+      - TEST="ARM64"
+    arch: arm64
+    compiler: gcc
+    script:
+      - cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - make
+      - make test
+
+  #
   # Ceres-related tests
   #
   - os: linux


### PR DESCRIPTION
This PR adds a new CI job to compile `manif` on arm64 architecture (e.g. Raspberry Pi with 64-bit OS).