### PR TITLE
Add test for smallAdj and fix so2 se3

### DIFF
--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -290,11 +290,24 @@ template <typename _Derived>
 typename SE3TangentBase<_Derived>::Jacobian
 SE3TangentBase<_Derived>::smallAdj() const
 {
+  /// @note Chirikjian (close to Eq.10.94)
+  /// says
+  ///       ad(g) = |  Omega  0   |
+  ///               |   V   Omega |
+  ///
+  /// considering vee(log(g)) = (w;v)
+  ///
+  /// but this is
+  ///       ad(g) = |  Omega  V   |
+  ///               |   0   Omega |
+  ///
+  /// considering vee(log(g)) = (v;w)
+
   Jacobian smallAdj;
-  smallAdj.template topRightCorner<3,3>().setZero();
+  smallAdj.template topRightCorner<3,3>() = skew(v());
   smallAdj.template topLeftCorner<3,3>() = skew(w());
   smallAdj.template bottomRightCorner<3,3>() = smallAdj.template topLeftCorner<3,3>();
-  smallAdj.template bottomLeftCorner<3,3>() = skew(v());
+  smallAdj.template bottomLeftCorner<3,3>().setZero();
 
   return smallAdj;
 }

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -166,7 +166,7 @@ template <typename _Derived>
 typename SO2TangentBase<_Derived>::Jacobian
 SO2TangentBase<_Derived>::smallAdj() const
 {
-  static const Jacobian smallAdj = Jacobian::Constant(Scalar(1));
+  static const Jacobian smallAdj = Jacobian::Zero();
   return smallAdj;
 }
 

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -68,7 +68,9 @@
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_NUMERICAL_STABILITY) \
   { evalNumericalStability(); }                                           \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_NORMALIZE)           \
-  { evalNormalize(); }
+  { evalNormalize(); }                                                    \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_SMALL_ADJ)           \
+  { evalSmallAdj(); }
 
 #define MANIF_TEST_JACOBIANS(manifold)                                            \
   using TEST_##manifold##_JACOBIANS_TESTER = JacobianTester<manifold>;            \
@@ -535,6 +537,14 @@ public:
     EXPECT_NO_THROW(
       LieGroup b = map
     );
+  }
+
+  void evalSmallAdj()
+  {
+    const Tangent delta_other = Tangent::Random();
+
+    EXPECT_EIGEN_NEAR((delta.smallAdj() * delta_other).hat(),
+                      delta.hat() * delta_other.hat() - delta_other.hat() * delta.hat());
   }
 
 protected:


### PR DESCRIPTION
Add a test for `smallAdj`:
```cpp
(x.smallAdj() * y).hat() = x.hat() * y.hat() - y.hat() * x.hat();
```

Fix `so2/se3.smallAdj()`.