### PR TITLE
Fix Vector typedef and add small test

### DIFF
--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -33,7 +33,7 @@ struct traits<SE2<_Scalar>>
   using Transformation = Eigen::Matrix<Scalar, 3, 3>;
   using Rotation       = Eigen::Matrix<Scalar, Dim, Dim>;
   using Translation    = Eigen::Matrix<Scalar, Dim, 1>;
-  using Vector         = Eigen::Matrix<Scalar, DoF, 1>;
+  using Vector         = Eigen::Matrix<Scalar, Dim, 1>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -36,7 +36,7 @@ struct traits<SE3<_Scalar>>
   using Transformation = Eigen::Matrix<Scalar, 4, 4>;
   using Rotation       = Eigen::Matrix<Scalar, Dim, Dim>;
   using Translation    = Eigen::Matrix<Scalar, Dim, 1>;
-  using Vector         = Eigen::Matrix<Scalar, DoF, 1>;
+  using Vector         = Eigen::Matrix<Scalar, Dim, 1>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -31,8 +31,8 @@ struct traits<SO2<_Scalar>>
 
   using Jacobian       = Eigen::Matrix<Scalar, DoF, DoF>;
   using Transformation = Eigen::Matrix<Scalar, 3, 3>;
-  using Rotation       = Eigen::Matrix<Scalar, 2, 2>;
-  using Vector         = Eigen::Matrix<Scalar, DoF, 1>;
+  using Rotation       = Eigen::Matrix<Scalar, Dim, Dim>;
+  using Vector         = Eigen::Matrix<Scalar, Dim, 1>;
 };
 
 } /* namespace internal */

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -32,7 +32,7 @@ struct traits<SO3<_Scalar>>
   using Jacobian       = Eigen::Matrix<Scalar, DoF, DoF>;
   using Transformation = Eigen::Matrix<Scalar, 4, 4>;
   using Rotation       = Eigen::Matrix<Scalar, Dim, Dim>;
-  using Vector         = Eigen::Matrix<Scalar, DoF, 1>;
+  using Vector         = Eigen::Matrix<Scalar, Dim, 1>;
 };
 
 } /* namespace internal */

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -70,7 +70,9 @@
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_NORMALIZE)           \
   { evalNormalize(); }                                                    \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_SMALL_ADJ)           \
-  { evalSmallAdj(); }
+  { evalSmallAdj(); }                                                     \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_IDENTITY_ACT_POINT)  \
+  { evalIdentityActPoint(); }
 
 #define MANIF_TEST_JACOBIANS(manifold)                                            \
   using TEST_##manifold##_JACOBIANS_TESTER = JacobianTester<manifold>;            \
@@ -545,6 +547,17 @@ public:
 
     EXPECT_EIGEN_NEAR((delta.smallAdj() * delta_other).hat(),
                       delta.hat() * delta_other.hat() - delta_other.hat() * delta.hat());
+  }
+
+  void evalIdentityActPoint()
+  {
+    using Point = typename LieGroup::Vector;
+
+    Point pin = Point::Random();
+
+    Point pout = LieGroup::Identity().act(pin);
+
+    EXPECT_EIGEN_NEAR(pin, pout);
   }
 
 protected:


### PR DESCRIPTION
Fix the `Vector` typedef in all groups.
Add a test that rely on `act` which actually acts on points, not vectors, thus the `Point` typedef in the test.

fix #117