### PR TITLE
Do not install package manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,6 @@ install(
   DESTINATION include
 )
 
-install(FILES package.xml
-  DESTINATION share/${PROJECT_NAME}
-#  DESTINATION "${config_install_dir}"
-)
 
 ##############
 ## Examples ##


### PR DESCRIPTION
Do not install the `package.xml` file in `devel/share/manif`.
Fix #120 