### PR TITLE
Add default eps to TangentBase::isApprox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - cd build
 
   # Update / Install Eigen
-  - wget http://bitbucket.org/eigen/eigen/get/3.3-beta1.tar.gz && tar xzf 3.3-beta1.tar.gz && sudo cp -Rp eigen-eigen-ce5a455b34c0 /usr/local/include/eigen3;
+  - wget https://gitlab.com/libeigen/eigen/-/archive/3.3-beta1/eigen-3.3-beta1.tar.gz && tar xzf eigen-3.3-beta1.tar.gz && sudo cp -Rp eigen-3.3-beta1 /usr/local/include/eigen3;
 
   # #
   # # Update / Install CMake

--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -589,7 +589,7 @@ template <typename _DerivedOther>
 bool LieGroupBase<_Derived>::operator ==(
     const LieGroupBase<_DerivedOther>& m)
 {
-  return isApprox(m, Constants<Scalar>::eps);
+  return isApprox(m);
 }
 
 template <typename _Derived>

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -240,7 +240,7 @@ public:
    */
   template <typename _EigenDerived>
   bool isApprox(const Eigen::MatrixBase<_EigenDerived>& v,
-                const Scalar eps) const;
+                const Scalar eps = Constants<Scalar>::eps) const;
 
   /**
    * @brief Evaluate whether this and t are 'close'.
@@ -252,7 +252,7 @@ public:
    */
   template <typename _DerivedOther>
   bool isApprox(const TangentBase<_DerivedOther>& t,
-                const Scalar eps) const;
+                const Scalar eps = Constants<Scalar>::eps) const;
 
   // Some operators
 
@@ -832,7 +832,7 @@ bool operator ==(
     const TangentBase<_Derived>& ta,
     const TangentBase<_DerivedOther>& tb)
 {
-  return ta.isApprox(tb, Constants<typename TangentBase<_Derived>::Scalar>::eps);
+  return ta.isApprox(tb);
 }
 
 template <typename _Derived, typename _EigenDerived>
@@ -840,7 +840,7 @@ bool operator ==(
     const TangentBase<_Derived>& t,
     const Eigen::MatrixBase<_EigenDerived>& v)
 {
-  return t.isApprox(v, Constants<typename TangentBase<_Derived>::Scalar>::eps);
+  return t.isApprox(v);
 }
 
 // Utils

--- a/test/gtest/CMakeLists.txt.in
+++ b/test/gtest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           v1.8.x
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Add a default `eps` value to `TangentBase::isApprox`.
This should have been done in d584b109e56e68db966e54b98548f5f7317d95f9.

Fix #123.

Edit:
Pushed two extra commits, didn't want to open a separate PR for those:
- download `gtest` `v1.8.x` explicitly instead of `master`. Branch `master` had some recent changes that requiers the `cpp11` flag for older compilers (found that [here](https://github.com/oracle/ktf/issues/10#issuecomment-440629294)).
- download `Eigen` from the official Gitlab repo rather than the deprecated Bitbucket one in CI. There were some spurious timeout issues in CI.