### PR TITLE
Add public non-const coeffs

### DIFF
--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -36,15 +36,13 @@ struct LieGroupBase
   template <typename _Scalar>
   using LieGroupTemplate = typename internal::traitscast<LieGroup, _Scalar>::cast;
 
-protected:
-
-  //! @brief Access the underlying data by reference
-  DataType& coeffs_nonconst();
-
 public:
 
   //! @brief Helper for skipping an optional parameter.
   static const OptJacobianRef _;
+
+  //! @brief Access the underlying data by const reference
+  DataType& coeffs();
 
   //! @brief Access the underlying data by const reference
   const DataType& coeffs() const;
@@ -322,9 +320,9 @@ LieGroupBase<_Derived>::_ = {};
 
 template <typename _Derived>
 typename LieGroupBase<_Derived>::DataType&
-LieGroupBase<_Derived>::coeffs_nonconst()
+LieGroupBase<_Derived>::coeffs()
 {
-  return derived().coeffs_nonconst();
+  return derived().coeffs();
 }
 
 template <typename _Derived>
@@ -338,7 +336,7 @@ template <typename _Derived>
 typename LieGroupBase<_Derived>::Scalar*
 LieGroupBase<_Derived>::data()
 {
-  return derived().coeffs_nonconst().data();
+  return derived().coeffs().data();
 }
 
 template <typename _Derived>
@@ -570,7 +568,7 @@ _Derived&
 LieGroupBase<_Derived>::operator =(
     const LieGroupBase<_Derived>& m)
 {
-  derived().coeffs_nonconst() = m.coeffs();
+  derived().coeffs() = m.coeffs();
   return derived();
 }
 
@@ -580,7 +578,7 @@ _Derived&
 LieGroupBase<_Derived>::operator =(
     const LieGroupBase<_DerivedOther>& m)
 {
-  derived().coeffs_nonconst() = m.coeffs();
+  derived().coeffs() = m.coeffs();
   return derived();
 }
 

--- a/include/manif/impl/rn/Rn.h
+++ b/include/manif/impl/rn/Rn.h
@@ -82,14 +82,14 @@ public:
   // LieGroup common API
 
   //! Get a const reference to the underlying DataType.
+  DataType& coeffs();
+
+  //! Get a const reference to the underlying DataType.
   const DataType& coeffs() const;
 
   // Rn specific API
 
 protected:
-
-  friend struct LieGroupBase<Rn<Scalar, _N>>;
-  DataType& coeffs_nonconst();
 
   DataType data_;
 };
@@ -147,7 +147,7 @@ Rn<_Scalar, _N>::Rn(const LieGroupBase<_DerivedOther>& o)
 
 template <typename _Scalar, unsigned int _N>
 typename Rn<_Scalar, _N>::DataType&
-Rn<_Scalar, _N>::coeffs_nonconst()
+Rn<_Scalar, _N>::coeffs()
 {
   return data_;
 }

--- a/include/manif/impl/rn/Rn_base.h
+++ b/include/manif/impl/rn/Rn_base.h
@@ -111,10 +111,6 @@ public:
    */
   template<typename _EigenDerived>
   _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
-
-protected:
-
-  using Base::coeffs_nonconst;
 };
 
 template <typename _Derived>
@@ -131,7 +127,7 @@ template <typename _EigenDerived>
 _Derived& RnBase<_Derived>::operator =(
   const Eigen::MatrixBase<_EigenDerived>& v)
 {
-  coeffs_nonconst() = v;
+  coeffs() = v;
   return *static_cast< _Derived* >(this);
 }
 

--- a/include/manif/impl/rn/Rn_map.h
+++ b/include/manif/impl/rn/Rn_map.h
@@ -49,12 +49,11 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  DataType& coeffs() { return data_; }
+
   const DataType& coeffs() const { return data_; }
 
 protected:
-
-  friend struct manif::LieGroupBase<Map<manif::Rn<_Scalar, _N>, 0>>;
-  DataType& coeffs_nonconst() { return data_; }
 
   DataType data_;
 };

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -133,6 +133,7 @@ public:
 
   // LieGroup common API
 
+  DataType& coeffs();
   const DataType& coeffs() const;
 
   // SE2 specific API
@@ -144,9 +145,6 @@ public:
   using Base::y;
 
 protected:
-
-  friend struct LieGroupBase<SE2<Scalar>>;
-  DataType& coeffs_nonconst();
 
   DataType data_;
 };
@@ -230,7 +228,7 @@ SE2<_Scalar>::SE2(const Eigen::Transform<_Scalar,2,Eigen::Isometry>& h)
 
 template <typename _Scalar>
 typename SE2<_Scalar>::DataType&
-SE2<_Scalar>::coeffs_nonconst()
+SE2<_Scalar>::coeffs()
 {
   return data_;
 }

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -149,10 +149,6 @@ public:
    * @brief Normalize the underlying complex number.
    */
   void normalize();
-
-protected:
-
-  using Base::coeffs_nonconst;
 };
 
 template <typename _Derived>
@@ -383,7 +379,7 @@ SE2Base<_Derived>::y() const
 template <typename _Derived>
 void SE2Base<_Derived>::normalize()
 {
-  coeffs_nonconst().template tail<2>().normalize();
+  coeffs().template tail<2>().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/se2/SE2_map.h
+++ b/include/manif/impl/se2/SE2_map.h
@@ -51,6 +51,7 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
   using Base::angle;
@@ -60,9 +61,6 @@ public:
   using Base::y;
 
 protected:
-
-  friend struct manif::LieGroupBase<Map<manif::SE2<_Scalar>, 0>>;
-  DataType& coeffs_nonconst() { return data_; }
 
   DataType data_;
 };

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -137,14 +137,12 @@ public:
 
   // LieGroup common API
 
+  DataType& coeffs();
   const DataType& coeffs() const;
 
   // SE3 specific API
 
 protected:
-
-  friend struct LieGroupBase<SE3<Scalar>>;
-  DataType& coeffs_nonconst();
 
   DataType data_;
 };
@@ -233,7 +231,7 @@ SE3<_Scalar>::SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h)
 
 template <typename _Scalar>
 typename SE3<_Scalar>::DataType&
-SE3<_Scalar>::coeffs_nonconst()
+SE3<_Scalar>::coeffs()
 {
   return data_;
 }

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -155,10 +155,6 @@ public:
    */
   void normalize();
 
-protected:
-
-  using Base::coeffs_nonconst;
-
 public: /// @todo make protected
 
   Eigen::Map<const SO3<Scalar>> asSO3() const
@@ -168,7 +164,7 @@ public: /// @todo make protected
 
   Eigen::Map<SO3<Scalar>> asSO3()
   {
-    return Eigen::Map<SO3<Scalar>>(coeffs_nonconst().data()+3);
+    return Eigen::Map<SO3<Scalar>>(coeffs().data()+3);
   }
 };
 
@@ -361,7 +357,7 @@ SE3Base<_Derived>::z() const
 template <typename _Derived>
 void SE3Base<_Derived>::normalize()
 {
-  coeffs_nonconst().template tail<4>().normalize();
+  coeffs().template tail<4>().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/se3/SE3_map.h
+++ b/include/manif/impl/se3/SE3_map.h
@@ -51,12 +51,10 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
 protected:
-
-  friend struct manif::LieGroupBase<Map<manif::SE3<_Scalar>, 0>>;
-  DataType& coeffs_nonconst() { return data_; }
 
   DataType data_;
 };

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -94,6 +94,7 @@ public:
   // LieGroup common API
 
   //! Get a const reference to the underlying DataType.
+  DataType& coeffs();
   const DataType& coeffs() const;
 
   // SO2 specific API
@@ -101,9 +102,6 @@ public:
   using Base::angle;
 
 protected:
-
-  friend struct LieGroupBase<SO2<Scalar>>;
-  DataType& coeffs_nonconst();
 
   DataType data_;
 };
@@ -163,7 +161,7 @@ SO2<_Scalar>::SO2(const Scalar theta)
 
 template <typename _Scalar>
 typename SO2<_Scalar>::DataType&
-SO2<_Scalar>::coeffs_nonconst()
+SO2<_Scalar>::coeffs()
 {
   return data_;
 }

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -129,9 +129,7 @@ public:
    */
   void normalize();
 
-protected:
-
-  using Base::coeffs_nonconst;
+// protected:
 
   /// @todo given a Eigen::Map<const SO2>
   /// coeffs()->x() return a reference to
@@ -297,7 +295,7 @@ SO2Base<_Derived>::angle() const
 template <typename _Derived>
 void SO2Base<_Derived>::normalize()
 {
-  coeffs_nonconst().normalize();
+  coeffs().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/so2/SO2_map.h
+++ b/include/manif/impl/so2/SO2_map.h
@@ -51,12 +51,10 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
 protected:
-
-  friend struct manif::LieGroupBase<Map<manif::SO2<_Scalar>, 0>>;
-  DataType& coeffs_nonconst() { return data_; }
 
   DataType data_;
 };

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -113,12 +113,10 @@ public:
   SO3(const Scalar roll, const Scalar pitch,
       const Scalar yaw);
 
+  DataType& coeffs();
   const DataType& coeffs() const;
 
 protected:
-
-  friend struct LieGroupBase<SO3<Scalar>>;
-  DataType& coeffs_nonconst();
 
   DataType data_;
 };
@@ -198,7 +196,7 @@ SO3<_Scalar>::SO3(const Scalar roll,
 
 template <typename _Scalar>
 typename SO3<_Scalar>::DataType&
-SO3<_Scalar>::coeffs_nonconst()
+SO3<_Scalar>::coeffs()
 {
   return data_;
 }

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -124,10 +124,6 @@ public:
    * @brief Normalize the underlying quaternion.
    */
   void normalize();
-
-protected:
-
-  using Base::coeffs_nonconst;
 };
 
 template <typename _Derived>
@@ -347,7 +343,7 @@ SO3Base<_Derived>::quat() const
 template <typename _Derived>
 void SO3Base<_Derived>::normalize()
 {
-  coeffs_nonconst().normalize();
+  coeffs().normalize();
 }
 
 namespace internal {

--- a/include/manif/impl/so3/SO3_map.h
+++ b/include/manif/impl/so3/SO3_map.h
@@ -51,12 +51,10 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
 protected:
-
-  friend struct manif::LieGroupBase<Map<manif::SO3<_Scalar>, 0>>;
-  DataType& coeffs_nonconst() { return data_; }
 
   DataType data_;
 };


### PR DESCRIPTION
Add a public non-const `coeffs` to `LieGroup` objects.

Also remove the protected `coeffs_nonconst`.

Fix #132.