### PR TITLE
Add MANIF_ASSERT

### DIFF
--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -3,6 +3,12 @@
 
 #include <stdexcept> // for std::runtime_error
 
+#ifdef NDEBUG
+# ifndef MANIF_NO_DEBUG
+#  define MANIF_NO_DEBUG
+# endif
+#endif
+
 namespace manif {
 
 struct runtime_error : std::runtime_error
@@ -72,6 +78,21 @@ raise(Args&&... args)
                       __MANIF_CHECK_MSG_EXCEPT,   \
                       __MANIF_CHECK_MSG,          \
                       __MANIF_CHECK)(__VA_ARGS__) )
+
+// Assertions cost run time and can be turned off.
+// You can suppress MANIF_ASSERT by defining
+// MANIF_NO_DEBUG before including manif headers.
+// MANIF_NO_DEBUG is undefined by default unless NDEBUG is defined.
+#ifndef MANIF_NO_DEBUG
+  #define MANIF_ASSERT(...)                         \
+    __MANIF_EXPAND(                                 \
+    __MANIF_GET_MACRO_3(__VA_ARGS__,                \
+                        __MANIF_CHECK_MSG_EXCEPT,   \
+                        __MANIF_CHECK_MSG,          \
+                        __MANIF_CHECK)(__VA_ARGS__) )
+#else
+  #define MANIF_ASSERT(...) ((void)0)
+#endif
 
 #define MANIF_NOT_IMPLEMENTED_YET \
   MANIF_THROW("Not implemented yet !");

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -159,10 +159,10 @@ SE2<_Scalar>::SE2(const Eigen::MatrixBase<_EigenDerived>& data)
   : data_(data)
 {
   using std::abs;
-  MANIF_CHECK(abs(data_.template tail<2>().norm()-Scalar(1)) <
-              Constants<Scalar>::eps_s,
-              "SE2 constructor argument not normalized !",
-              invalid_argument);
+  MANIF_ASSERT(abs(data_.template tail<2>().norm()-Scalar(1)) <
+               Constants<Scalar>::eps_s,
+               "SE2 constructor argument not normalized !",
+               invalid_argument);
 }
 
 template <typename _Scalar>

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -157,10 +157,10 @@ SE3<_Scalar>::SE3(const Eigen::MatrixBase<_EigenDerived>& data)
   : data_(data)
 {
   using std::abs;
-  MANIF_CHECK(abs(data_.template tail<4>().norm()-Scalar(1)) <
-              Constants<Scalar>::eps_s,
-              "SE3 constructor argument not normalized !",
-              invalid_argument);
+  MANIF_ASSERT(abs(data_.template tail<4>().norm()-Scalar(1)) <
+               Constants<Scalar>::eps_s,
+               "SE3 constructor argument not normalized !",
+               invalid_argument);
 }
 
 template <typename _Scalar>

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -116,9 +116,9 @@ SO2<_Scalar>::SO2(const Eigen::MatrixBase<_EigenDerived>& data)
   : data_(data)
 {
   using std::abs;
-  MANIF_CHECK(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-              "SO2 constructor argument not normalized !",
-              invalid_argument);
+  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+               "SO2 constructor argument not normalized !",
+               invalid_argument);
 }
 
 template <typename _Scalar>

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -131,9 +131,9 @@ SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
   : data_(data)
 {
   using std::abs;
-  MANIF_CHECK(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-              "SO3 constructor argument not normalized !",
-              invalid_argument);
+  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+               "SO3 constructor argument not normalized !",
+               invalid_argument);
 }
 
 template <typename _Scalar>

--- a/test/se2/gtest_se2.cpp
+++ b/test/se2/gtest_se2.cpp
@@ -84,25 +84,6 @@ TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(MANIF_PI/4., se2.angle());
 }
 
-TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
-{
-  EXPECT_THROW(
-    SE2d se2(SE2d(4, 2, 1, 1)),
-    manif::invalid_argument
-  );
-
-  EXPECT_THROW(
-    SE2d se2(SE2d::DataType(4, 2, 1, 1)),
-    manif::invalid_argument
-  );
-
-  try {
-    SE2d se2(SE2d::DataType(4, 2, 1, 1));
-  } catch (manif::invalid_argument& e) {
-    EXPECT_FALSE(std::string(e.what()).empty());
-  }
-}
-
 TEST(TEST_SE2, TEST_SE2_COEFFS)
 {
   SE2d se2(4, 2, 0);
@@ -523,6 +504,27 @@ TEST(TEST_SE2, TEST_SE2_ACT)
   EXPECT_NEAR(1, transformed_point.y(), 1e-15);
 }
 
+#ifndef MANIF_NO_DEBUG
+
+TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SE2d se2(SE2d(4, 2, 1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SE2d se2(SE2d::DataType(4, 2, 1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SE2d se2(SE2d::DataType(4, 2, 1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SE2, TEST_SE2_CONSTRUCTOR_UNNORMALIZED)
 {
   using DataType = typename SE2d::DataType;
@@ -547,6 +549,8 @@ TEST(TEST_SE2, TEST_SE2_NORMALIZE)
     SE2d b = map
   );
 }
+
+#endif
 
 MANIF_TEST(SE2d);
 

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -82,27 +82,6 @@ TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(1, se3.coeffs()(6));
 }
 
-TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
-{
-  // EXPECT_THROW(
-  //   SE3d se3(SE3d(1, 1)),
-  //   manif::invalid_argument
-  // );
-
-  SE3d::DataType values; values << 0,0,0, 1,1,1,1;
-
-  EXPECT_THROW(
-    SE3d se3(values),
-    manif::invalid_argument
-  );
-
-  try {
-    SE3d se3(values);
-  } catch (manif::invalid_argument& e) {
-    EXPECT_FALSE(std::string(e.what()).empty());
-  }
-}
-
 TEST(TEST_SE3, TEST_SE3_DATA)
 {
   SE3d::DataType values; values << 0,0,0, 0,0,0,1;
@@ -353,6 +332,29 @@ TEST(TEST_SE3, TEST_SE3_ISOMETRY)
   EXPECT_DOUBLE_EQ(3, se3h.matrix()(2,3));
 }
 
+#ifndef MANIF_NO_DEBUG
+
+TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  // EXPECT_THROW(
+  //   SE3d se3(SE3d(1, 1)),
+  //   manif::invalid_argument
+  // );
+
+  SE3d::DataType values; values << 0,0,0, 1,1,1,1;
+
+  EXPECT_THROW(
+    SE3d se3(values),
+    manif::invalid_argument
+  );
+
+  try {
+    SE3d se3(values);
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_UNNORMALIZED)
 {
   using DataType = typename SE3d::DataType;
@@ -377,6 +379,8 @@ TEST(TEST_SE3, TEST_SE3_NORMALIZE)
     SE3d b = map
   );
 }
+
+#endif
 
 MANIF_TEST(SE3d);
 

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -42,25 +42,6 @@ TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_COPY)
   EXPECT_DOUBLE_EQ(MANIF_PI/4., so2.angle());
 }
 
-TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
-{
-  EXPECT_THROW(
-    SO2d so2(SO2d(1, 1)),
-    manif::invalid_argument
-  );
-
-  EXPECT_THROW(
-    SO2d so2(SO2d::DataType(1, 1)),
-    manif::invalid_argument
-  );
-
-  try {
-    SO2d so2(SO2d::DataType(1, 1));
-  } catch (manif::invalid_argument& e) {
-    EXPECT_FALSE(std::string(e.what()).empty());
-  }
-}
-
 TEST(TEST_SO2, TEST_SO2_COEFFS)
 {
   SO2d so2(0);
@@ -551,6 +532,27 @@ TEST(TEST_SO2, TEST_SO2_ACT)
   EXPECT_NEAR(+1, transformed_point.y(), 1e-15);
 }
 
+#ifndef MANIF_NO_DEBUG
+
+TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SO2d so2(SO2d(1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SO2d so2(SO2d::DataType(1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SO2d so2(SO2d::DataType(1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SO2, TEST_SO2_CONSTRUCTOR_UNNORMALIZED)
 {
   using DataType = typename SO2d::DataType;
@@ -575,6 +577,8 @@ TEST(TEST_SO2, TEST_SO2_NORMALIZE)
     SO2d b = map
   );
 }
+
+#endif
 
 MANIF_TEST(SO2d);
 

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -56,25 +56,6 @@ TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_ROLL_PITCH_YAW)
   EXPECT_DOUBLE_EQ(1, so3.w());
 }
 
-TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
-{
-  EXPECT_THROW(
-    SO3d so3(SO3d(1, 1, 1, 1)),
-    manif::invalid_argument
-  );
-
-  EXPECT_THROW(
-    SO3d so3(SO3d::DataType(1, 1, 1, 1)),
-    manif::invalid_argument
-  );
-
-  try {
-    SO3d so3(SO3d::DataType(1, 1, 1, 1));
-  } catch (manif::invalid_argument& e) {
-    EXPECT_FALSE(std::string(e.what()).empty());
-  }
-}
-
 TEST(TEST_SO3, TEST_SO3_IDENTITY)
 {
   SO3d so3;
@@ -566,6 +547,27 @@ TEST(TEST_SO3, TEST_SO3_ACT)
   EXPECT_NEAR( 1, transformed_point.z(), 1e-15);
 }
 
+#ifndef MANIF_NO_DEBUG
+
+TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    SO3d so3(SO3d(1, 1, 1, 1)),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    SO3d so3(SO3d::DataType(1, 1, 1, 1)),
+    manif::invalid_argument
+  );
+
+  try {
+    SO3d so3(SO3d::DataType(1, 1, 1, 1));
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
 TEST(TEST_SO3, TEST_SO3_CONSTRUCTOR_UNNORMALIZED)
 {
   using DataType = typename SO3d::DataType;
@@ -590,6 +592,8 @@ TEST(TEST_SO3, TEST_SO3_NORMALIZE)
     SO3d b = map
   );
 }
+
+#endif
 
 MANIF_TEST(SO3d);
 


### PR DESCRIPTION
Add macro `MANIF_ASSERT`.  

The macro asserts that a condition is true or throws otherwise. It replaces `MANIF_CHECK` for a couple numerical checks as requested in [this comment](https://github.com/artivis/manif/issues/132#issuecomment-640200391).

`MANIF_ASSERT` macro can be disabled by either defining `MANIF_NO_DEBUG` or the usual `NDEBUG`.