### PR TITLE
Review copy construstor/assignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,24 @@ matrix:
       - make test
 
   #
+  # G++ 8
+  #
+  - os: linux
+    env:
+      - TEST="G++ 8"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+          - g++-8
+    script:
+      - cmake -DCMAKE_CXX_COMPILER="g++-8" -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - make
+      - make test
+
+  #
   # G++ 9
   #
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,24 @@ matrix:
       - make test
 
   #
+  # G++ 9
+  #
+  - os: linux
+    env:
+      - TEST="G++ 9"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-9
+          - g++-9
+    script:
+      - cmake -DCMAKE_CXX_COMPILER="g++-9" -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - make
+      - make test
+
+  #
   # Clang 3.8
   #
   - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,10 @@ endif()
 if(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
   message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS},"
                   "but this version has a [bug](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1643)")
-endif(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
+elseif(${EIGEN3_VERSION} VERSION_LESS "3.3.8")
+  message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS}. "
+                  "Beware that the move semantic has a bug and resolves to a simple copy.")
+endif()
 
 # Options. Turn on with 'cmake -DBUILD_TESTING=ON'.
 # catkin build manif --cmake-args -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON

--- a/examples/se2_localization.cpp
+++ b/examples/se2_localization.cpp
@@ -103,8 +103,6 @@
 
 #include "manif/SE2.h"
 
-#include <Eigen/Dense>
-
 #include <vector>
 
 #include <iostream>

--- a/examples/se2_sam.cpp
+++ b/examples/se2_sam.cpp
@@ -180,9 +180,6 @@
 // manif
 #include "manif/SE2.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/examples/se3_localization.cpp
+++ b/examples/se3_localization.cpp
@@ -103,8 +103,6 @@
 
 #include "manif/SE3.h"
 
-#include <Eigen/Dense>
-
 #include <vector>
 
 #include <iostream>

--- a/examples/se3_sam.cpp
+++ b/examples/se3_sam.cpp
@@ -180,9 +180,6 @@
 // manif
 #include "manif/SE3.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/examples/se3_sam_selfcalib.cpp
+++ b/examples/se3_sam_selfcalib.cpp
@@ -182,9 +182,6 @@
 // manif
 #include "manif/SE3.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/external/lt/lt/optional.hpp
+++ b/external/lt/lt/optional.hpp
@@ -391,7 +391,8 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
   using optional_operations_base<T>::optional_operations_base;
 
   optional_copy_base() = default;
-  optional_copy_base(const optional_copy_base &rhs) {
+  optional_copy_base(const optional_copy_base &rhs)
+    : optional_operations_base<T>() {
     if (rhs.has_value()) {
       this->construct(rhs.get());
     } else {

--- a/include/manif/impl/assignment_assert.h
+++ b/include/manif/impl/assignment_assert.h
@@ -1,0 +1,24 @@
+#ifndef _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_
+#define _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_
+
+namespace manif {
+namespace internal {
+
+template <typename Derived>
+struct AssignmentEvaluatorImpl
+{
+  template <typename T> static void run_impl(const T&) { }
+};
+
+template <typename Derived>
+struct AssignmentEvaluator : AssignmentEvaluatorImpl<Derived>
+{
+  using Base = AssignmentEvaluatorImpl<Derived>;
+
+  template <typename T> void run(T&& t) { Base::run_impl(std::forward<T>(t)); }
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_

--- a/include/manif/impl/eigen.h
+++ b/include/manif/impl/eigen.h
@@ -2,6 +2,8 @@
 #define _MANIF_MANIF_EIGEN_H_
 
 #include <Eigen/Core>
+#include <Eigen/LU> // for mat.inverse()
+#include <Eigen/Geometry>
 
 /**
  * @note static_cast<int> to avoid -Wno-enum-compare

--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -5,6 +5,7 @@
 #include "manif/impl/traits.h"
 #include "manif/impl/eigen.h"
 #include "manif/impl/tangent_base.h"
+#include "manif/impl/assignment_assert.h"
 
 #include "manif/constants.h"
 
@@ -40,6 +41,37 @@ public:
 
   //! @brief Helper for skipping an optional parameter.
   static const OptJacobianRef _;
+
+protected:
+
+  MANIF_DEFAULT_CONSTRUCTOR(LieGroupBase)
+
+public:
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   * @note This is a special case of the templated operator=. Its purpose is to
+   * prevent a default operator= from hiding the templated operator=.
+   */
+  _Derived& operator =(const LieGroupBase& m);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   */
+  template <typename _DerivedOther>
+  _Derived& operator =(const LieGroupBase<_DerivedOther>& m);
+
+  /**
+   * @brief Assignment operator given Eigen object.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   */
+  template <typename _EigenDerived>
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& data);
 
   //! @brief Access the underlying data by const reference
   DataType& coeffs();
@@ -235,21 +267,6 @@ public:
   // Some operators
 
   /**
-   * @brief Assignment operator.
-   * @param[in] An element of the Lie group.
-   * @return A reference to this.
-   */
-  _Derived& operator =(const LieGroupBase<_Derived>& m);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] An element of the Lie group.
-   * @return A reference to this.
-   */
-  template <typename _DerivedOther>
-  _Derived& operator =(const LieGroupBase<_DerivedOther>& m);
-
-  /**
    * @brief Equality operator.
    * @param[in] An element of the same Lie group.
    * @return true if the Lie group element m is 'close' to this,
@@ -301,10 +318,10 @@ public:
   //! Static helper to create a random object of the Lie group.
   static LieGroup Random();
 
-private:
+protected:
 
-  _Derived& derived() { return *static_cast< _Derived* >(this); }
-  const _Derived& derived() const { return *static_cast< const _Derived* >(this); }
+  inline _Derived& derived() & noexcept { return *static_cast< _Derived* >(this); }
+  inline const _Derived& derived() const & noexcept { return *static_cast< const _Derived* >(this); }
 };
 
 template <typename _Derived>
@@ -317,6 +334,37 @@ constexpr int LieGroupBase<_Derived>::RepSize;
 template <typename _Derived>
 const typename LieGroupBase<_Derived>::OptJacobianRef
 LieGroupBase<_Derived>::_ = {};
+
+// Copy
+
+template <typename _Derived>
+_Derived&
+LieGroupBase<_Derived>::operator =(const LieGroupBase& m)
+{
+  derived().coeffs() = m.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+_Derived&
+LieGroupBase<_Derived>::operator =(const LieGroupBase<_DerivedOther>& m)
+{
+  derived().coeffs() = m.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+_Derived&
+LieGroupBase<_Derived>::operator =(const Eigen::MatrixBase<_EigenDerived>& data)
+{
+  internal::AssignmentEvaluator<
+      typename internal::traits<_Derived>::Base>().run(data);
+
+  derived().coeffs() = data;
+  return derived();
+}
 
 template <typename _Derived>
 typename LieGroupBase<_Derived>::DataType&
@@ -562,25 +610,6 @@ LieGroupBase<_Derived>::act(const Vector& v,
 }
 
 // Operators
-
-template <typename _Derived>
-_Derived&
-LieGroupBase<_Derived>::operator =(
-    const LieGroupBase<_Derived>& m)
-{
-  derived().coeffs() = m.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _DerivedOther>
-_Derived&
-LieGroupBase<_Derived>::operator =(
-    const LieGroupBase<_DerivedOther>& m)
-{
-  derived().coeffs() = m.coeffs();
-  return derived();
-}
 
 template <typename _Derived>
 template <typename _DerivedOther>

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -117,7 +117,7 @@ raise(Args&&... args)
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF((Eigen::internal::traits<typename X::DataType>::Alignment>0))
 
 #define MANIF_MOVE_NOEXCEPT \
-  EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value)
+  noexcept(std::is_nothrow_move_constructible<Scalar>::value)
 
 #define MANIF_DEFAULT_CONSTRUCTOR(X)  \
   X() = default;                      \

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -116,6 +116,78 @@ raise(Args&&... args)
 #define MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND_TYPE(X) \
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF((Eigen::internal::traits<typename X::DataType>::Alignment>0))
 
+#define MANIF_DEFAULT_CONSTRUCTOR(X)  \
+  X() = default;                      \
+  ~X() = default;                     \
+  X(const X&) = default;              \
+  X(X&&) = delete;
+
+#define MANIF_GROUP_ML_ASSIGN_OP(X) \
+  _Derived& operator =(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_GROUP_ASSIGN_OP(X) \
+  X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_GROUP_MAP_ASSIGN_OP(X) \
+  Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+
+#define MANIF_TANGENT_ML_ASSIGN_OP(X) \
+  _Derived& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_TANGENT_ASSIGN_OP(X) \
+  X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_TANGENT_MAP_ASSIGN_OP(X) \
+  Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+
+/**
+ * @brief Automatically define:
+ * - copy constructor
+ * - copy constructor given Base object
+ * - copy constructor given Eigen object
+ */
+#define MANIF_COPY_CONSTRUCTOR(X)                                                           \
+  X(const X& o) : Base(), data_(o.coeffs()) { }                                             \
+  X(const Base& o) : Base(), data_(o.coeffs()) { }                                          \
+  template <typename D> X(const Eigen::MatrixBase<D>& o) : Base(), data_(o)                 \
+    { manif::internal::AssignmentEvaluator<Base>().run(o); }
+
+#define MANIF_COEFFS_FUNCTIONS()                      \
+  DataType& coeffs() & { return data_; }              \
+  const DataType& coeffs() const & { return data_; }
+
 // LieGroup - related macros
 
 #define MANIF_INHERIT_GROUP_AUTO_API    \

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -123,14 +123,19 @@ raise(Args&&... args)
   X() = default;                      \
   ~X() = default;                     \
   X(const X&) = default;              \
-  X(X&&) = delete;
+  X(X&&) = default;
 
 #define MANIF_GROUP_ML_ASSIGN_OP(X) \
   _Derived& operator =(const X& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _DerivedOther>\
   _Derived& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _EigenDerived>\
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); } \
+  _Derived& operator =(X&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(LieGroupBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(Eigen::MatrixBase<_EigenDerived>&& o) { coeffs() = std::move(o); return derived(); }
 
 #define MANIF_GROUP_ASSIGN_OP(X) \
   X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
@@ -139,7 +144,14 @@ raise(Args&&... args)
   template <typename _DerivedOther>\
   X& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _EigenDerived>\
-  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }\
+  X& operator=(X&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(X##Base<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(LieGroupBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(Eigen::MatrixBase<_EigenDerived>&& o) { coeffs() = std::move(o); return derived(); }
 
 #define MANIF_GROUP_MAP_ASSIGN_OP(X) \
   Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
@@ -148,14 +160,26 @@ raise(Args&&... args)
   template <typename _DerivedOther>\
   Map& operator =(const manif::LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
   template <typename _EigenDerived>\
-  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }\
+  Map& operator=(Map&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(manif::X##Base<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(manif::LieGroupBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(Eigen::MatrixBase<_EigenDerived>&& o) { coeffs() = std::move(o); return *this; }
 
 #define MANIF_TANGENT_ML_ASSIGN_OP(X) \
   _Derived& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _DerivedOther>\
   _Derived& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _EigenDerived>\
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }\
+  _Derived& operator=(X&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(TangentBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(Eigen::MatrixBase<_EigenDerived>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o); return derived(); }
 
 #define MANIF_TANGENT_ASSIGN_OP(X) \
   X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
@@ -164,7 +188,14 @@ raise(Args&&... args)
   template <typename _DerivedOther>\
   X& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
   template <typename _EigenDerived>\
-  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }\
+  X& operator=(X&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(X##Base<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(TangentBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(Eigen::MatrixBase<_EigenDerived>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o); return derived(); }
 
 #define MANIF_TANGENT_MAP_ASSIGN_OP(X) \
   Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
@@ -173,7 +204,14 @@ raise(Args&&... args)
   template <typename _DerivedOther>\
   Map& operator =(const manif::TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
   template <typename _EigenDerived>\
-  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }\
+  Map& operator=(Map&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(manif::X##Base<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(manif::TangentBase<_DerivedOther>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o.coeffs()); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(Eigen::MatrixBase<_EigenDerived>&& o) MANIF_MOVE_NOEXCEPT { coeffs() = std::move(o); return *this; }
 
 /**
  * @brief Automatically define:
@@ -181,11 +219,17 @@ raise(Args&&... args)
  * - copy constructor given Base object
  * - copy constructor given Eigen object
  */
-#define MANIF_COPY_CONSTRUCTOR(X)                                                           \
-  X(const X& o) : Base(), data_(o.coeffs()) { }                                             \
-  X(const Base& o) : Base(), data_(o.coeffs()) { }                                          \
-  template <typename D> X(const Eigen::MatrixBase<D>& o) : Base(), data_(o)                 \
-    { manif::internal::AssignmentEvaluator<Base>().run(o); }
+#define MANIF_COPY_CONSTRUCTOR(X)                                           \
+  X(const X& o) : Base(), data_(o.coeffs()) { }                             \
+  X(const Base& o) : Base(), data_(o.coeffs()) { }                          \
+  template <typename D> X(const Eigen::MatrixBase<D>& o) : Base(), data_(o) \
+    { manif::internal::AssignmentEvaluator<Base>().run(data_); }
+
+#define MANIF_MOVE_CONSTRUCTOR(X)                                                 \
+  X(X&& o) MANIF_MOVE_NOEXCEPT : Base(), data_(std::move(o.coeffs())) { }         \
+  X(Base&& o) MANIF_MOVE_NOEXCEPT : Base(), data_(std::move(o.coeffs())) { }      \
+  template <typename D> X(Eigen::MatrixBase<D>&& o) : Base(), data_(std::move(o)) \
+    { manif::internal::AssignmentEvaluator<Base>().run(data_); }
 
 #define MANIF_COEFFS_FUNCTIONS()                      \
   DataType& coeffs() & { return data_; }              \

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -116,6 +116,9 @@ raise(Args&&... args)
 #define MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND_TYPE(X) \
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF((Eigen::internal::traits<typename X::DataType>::Alignment>0))
 
+#define MANIF_MOVE_NOEXCEPT \
+  EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value)
+
 #define MANIF_DEFAULT_CONSTRUCTOR(X)  \
   X() = default;                      \
   ~X() = default;                     \

--- a/include/manif/impl/rn/Rn.h
+++ b/include/manif/impl/rn/Rn.h
@@ -56,6 +56,10 @@ private:
   using Base = RnBase<Rn<_Scalar, _N>>;
   using Type = Rn<_Scalar, _N>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -66,22 +70,17 @@ public:
   Rn()  = default;
   ~Rn() = default;
 
+  MANIF_COPY_CONSTRUCTOR(Rn)
+
   // Copy constructor given base
-  Rn(const Base& o);
-
-  template <typename _DerivedOther>
-  Rn(const RnBase<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   Rn(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  Rn(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(Rn)
 
   // LieGroup common API
 
-  //! Get a const reference to the underlying DataType.
+  //! Get a reference to the underlying DataType.
   DataType& coeffs();
 
   //! Get a const reference to the underlying DataType.
@@ -113,29 +112,6 @@ MANIF_EXTRA_GROUP_TYPEDEF(R6)
 MANIF_EXTRA_GROUP_TYPEDEF(R7)
 MANIF_EXTRA_GROUP_TYPEDEF(R8)
 MANIF_EXTRA_GROUP_TYPEDEF(R9)
-
-template <typename _Scalar, unsigned int _N>
-template <typename _EigenDerived>
-Rn<_Scalar, _N>::Rn(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-Rn<_Scalar, _N>::Rn(const Base& o)
-  : Rn(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _DerivedOther>
-Rn<_Scalar, _N>::Rn(const RnBase<_DerivedOther>& o)
-  : Rn(o.coeffs())
-{
-  //
-}
 
 template <typename _Scalar, unsigned int _N>
 template <typename _DerivedOther>

--- a/include/manif/impl/rn/Rn.h
+++ b/include/manif/impl/rn/Rn.h
@@ -71,6 +71,7 @@ public:
   ~Rn() = default;
 
   MANIF_COPY_CONSTRUCTOR(Rn)
+  MANIF_MOVE_CONSTRUCTOR(Rn)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/rn/RnTangent.h
+++ b/include/manif/impl/rn/RnTangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/rn/RnTangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/rn/RnTangent.h
+++ b/include/manif/impl/rn/RnTangent.h
@@ -51,6 +51,10 @@ private:
   using Base = RnTangentBase<RnTangent<_Scalar, _N>>;
   using Type = RnTangent<_Scalar, _N>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -62,17 +66,13 @@ public:
   RnTangent()  = default;
   ~RnTangent() = default;
 
-  // Copy constructor given base
-  RnTangent(const Base& o);
-  template <typename _DerivedOther>
-  RnTangent(const RnTangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(RnTangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   RnTangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  RnTangent(const Eigen::MatrixBase<_EigenDerived>& theta);
+  MANIF_TANGENT_ASSIGN_OP(RnTangent)
 
   // Tangent common API
 
@@ -105,35 +105,9 @@ MANIF_EXTRA_GROUP_TYPEDEF(R8Tangent)
 MANIF_EXTRA_GROUP_TYPEDEF(R9Tangent)
 
 template <typename _Scalar, unsigned int _N>
-RnTangent<_Scalar, _N>::RnTangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
 template <typename _DerivedOther>
-RnTangent<_Scalar, _N>::RnTangent(
-    const RnTangentBase<_DerivedOther>& o)
+RnTangent<_Scalar, _N>::RnTangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _DerivedOther>
-RnTangent<_Scalar, _N>::RnTangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _EigenDerived>
-RnTangent<_Scalar, _N>::RnTangent(
-    const Eigen::MatrixBase<_EigenDerived>& theta)
-  : data_(theta)
 {
   //
 }

--- a/include/manif/impl/rn/RnTangent.h
+++ b/include/manif/impl/rn/RnTangent.h
@@ -65,6 +65,7 @@ public:
   ~RnTangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(RnTangent)
+  MANIF_MOVE_CONSTRUCTOR(RnTangent)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/rn/RnTangent_base.h
+++ b/include/manif/impl/rn/RnTangent_base.h
@@ -28,8 +28,15 @@ public:
   MANIF_INHERIT_TANGENT_OPERATOR
   using Base::coeffs;
 
-  RnTangentBase()  = default;
-  ~RnTangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(RnTangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(RnTangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/rn/RnTangent_map.h
+++ b/include/manif/impl/rn/RnTangent_map.h
@@ -48,6 +48,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(RnTangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/rn/Rn_base.h
+++ b/include/manif/impl/rn/Rn_base.h
@@ -35,6 +35,15 @@ public:
   using Transformation = typename internal::traits<_Derived>::Transformation;
 
   // LieGroup common API
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(RnBase)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(RnBase)
 
   /**
    * @brief Get the inverse of this.
@@ -103,14 +112,6 @@ public:
    *           | 0 1 |
    */
   Transformation transform() const;
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] v An Eigen MatrixBase (vector expected).
-   * @return A reference to this.
-   */
-  template<typename _EigenDerived>
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
 };
 
 template <typename _Derived>
@@ -120,15 +121,6 @@ RnBase<_Derived>::transform() const
   Transformation T(Transformation::Identity());
   T.template topRightCorner<Dim,1>() = coeffs();
   return T;
-}
-
-template <typename _Derived>
-template <typename _EigenDerived>
-_Derived& RnBase<_Derived>::operator =(
-  const Eigen::MatrixBase<_EigenDerived>& v)
-{
-  coeffs() = v;
-  return *static_cast< _Derived* >(this);
 }
 
 template <typename _Derived>

--- a/include/manif/impl/rn/Rn_map.h
+++ b/include/manif/impl/rn/Rn_map.h
@@ -49,8 +49,9 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
-  DataType& coeffs() { return data_; }
+  MANIF_GROUP_MAP_ASSIGN_OP(Rn)
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
 protected:

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -75,6 +75,7 @@ public:
   ~SE2() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE2)
+  MANIF_MOVE_CONSTRUCTOR(SE2)
 
   // Copy constructor
   template <typename _DerivedOther>

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -56,6 +56,10 @@ private:
   using Base = SE2Base<SE2<_Scalar>>;
   using Type = SE2<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -70,18 +74,13 @@ public:
   SE2()  = default;
   ~SE2() = default;
 
-  // Copy constructor given base
-  SE2(const Base& o);
+  MANIF_COPY_CONSTRUCTOR(SE2)
 
-  template <typename _DerivedOther>
-  SE2(const SE2Base<_DerivedOther>& o);
-
+  // Copy constructor
   template <typename _DerivedOther>
   SE2(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE2(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SE2)
 
   /**
    * @brief Constructor given a translation and a unit complex number.
@@ -133,7 +132,16 @@ public:
 
   // LieGroup common API
 
+  /**
+   * @brief Access the underlying data
+   * @param[out] a reference to the underlying Eigen vector
+   */
   DataType& coeffs();
+
+  /**
+   * @brief Access the underlying data
+   * @param[out] a const reference to the underlying Eigen vector
+   */
   const DataType& coeffs() const;
 
   // SE2 specific API
@@ -146,43 +154,15 @@ public:
 
 protected:
 
+  //! Underlying data (Eigen) vector
   DataType data_;
 };
 
 MANIF_EXTRA_GROUP_TYPEDEF(SE2)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SE2<_Scalar>::SE2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.template tail<2>().norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "SE2 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SE2<_Scalar>::SE2(const Base& o)
-  : SE2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE2<_Scalar>::SE2(
-    const SE2Base<_DerivedOther>& o)
-  : SE2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE2<_Scalar>::SE2(
-    const LieGroupBase<_DerivedOther>& o)
+SE2<_Scalar>::SE2(const LieGroupBase<_DerivedOther>& o)
   : SE2(o.coeffs())
 {
   //
@@ -220,7 +200,7 @@ SE2<_Scalar>::SE2(const Scalar x, const Scalar y, const std::complex<Scalar>& c)
 }
 
 template <typename _Scalar>
-SE2<_Scalar>::SE2(const Eigen::Transform<_Scalar,2,Eigen::Isometry>& h)
+SE2<_Scalar>::SE2(const Eigen::Transform<_Scalar, 2, Eigen::Isometry>& h)
   : SE2(h.translation().x(), h.translation().y(), Eigen::Rotation2D<Scalar>(h.rotation()).angle())
 {
   //

--- a/include/manif/impl/se2/SE2Tangent.h
+++ b/include/manif/impl/se2/SE2Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SE2TangentBase<SE2Tangent<_Scalar>>;
   using Type = SE2Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SE2Tangent()  = default;
   ~SE2Tangent() = default;
 
-  // Copy constructor given base
-  SE2Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SE2Tangent(const SE2TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE2Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SE2Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE2Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SE2Tangent)
 
   SE2Tangent(const Scalar x, const Scalar y, const Scalar theta);
 
@@ -91,35 +91,9 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SE2Tangent);
 
 template <typename _Scalar>
-SE2Tangent<_Scalar>::SE2Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const SE2TangentBase<_DerivedOther>& o)
+SE2Tangent<_Scalar>::SE2Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/se2/SE2Tangent.h
+++ b/include/manif/impl/se2/SE2Tangent.h
@@ -63,6 +63,7 @@ public:
   ~SE2Tangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE2Tangent)
+  MANIF_MOVE_CONSTRUCTOR(SE2Tangent)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/se2/SE2Tangent.h
+++ b/include/manif/impl/se2/SE2Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se2/SE2Tangent_base.h"
 
-#include <Eigen/Dense>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -24,14 +24,22 @@ private:
 
 public:
 
-  SE2TangentBase()  = default;
-  ~SE2TangentBase() = default;
-
   MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
   MANIF_INHERIT_TANGENT_OPERATOR
 
   using Base::data;
   using Base::coeffs;
+
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE2TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SE2TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/se2/SE2Tangent_map.h
+++ b/include/manif/impl/se2/SE2Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SE2Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -415,10 +415,10 @@ struct AssignmentEvaluatorImpl<SE2Base<Derived>>
   {
     using std::abs;
     using Scalar = typename SE2Base<Derived>::Scalar;
-    MANIF_CHECK(abs(data.template tail<2>().norm()-Scalar(1)) <
-                Constants<Scalar>::eps_s,
-                "SE2 assigned data not normalized !",
-                invalid_argument);
+    MANIF_ASSERT(abs(data.template tail<2>().norm()-Scalar(1)) <
+                 Constants<Scalar>::eps_s,
+                 "SE2 assigned data not normalized !",
+                 invalid_argument);
   }
 };
 

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -38,6 +38,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE2Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SE2Base)
+
   /**
    * @brief Get the inverse of this.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -393,6 +403,22 @@ struct RandomEvaluatorImpl<SE2Base<Derived>>
   {
     using Tangent = typename LieGroupBase<Derived>::Tangent;
     m = Tangent::Random().exp();
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SE2Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SE2Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.template tail<2>().norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "SE2 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/se2/SE2_map.h
+++ b/include/manif/impl/se2/SE2_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SE2)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -59,6 +59,10 @@ private:
   using Base = SE3Base<SE3<_Scalar>>;
   using Type = SE3<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -75,18 +79,12 @@ public:
   SE3()  = default;
   ~SE3() = default;
 
-  // Copy constructor given base
-  SE3(const Base& o);
-
-  template <typename _DerivedOther>
-  SE3(const SE3Base<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE3)
 
   template <typename _DerivedOther>
   SE3(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE3(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SE3)
 
   /**
    * @brief Constructor given a translation and a unit quaternion.
@@ -150,53 +148,22 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SE3)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SE3<_Scalar>::SE3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.template tail<4>().norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "SE3 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SE3<_Scalar>::SE3(const Base& o)
-  : SE3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE3<_Scalar>::SE3(
-    const SE3Base<_DerivedOther>& o)
+SE3<_Scalar>::SE3(const LieGroupBase<_DerivedOther>& o)
   : SE3(o.coeffs())
 {
   //
 }
 
 template <typename _Scalar>
-template <typename _DerivedOther>
-SE3<_Scalar>::SE3(
-    const LieGroupBase<_DerivedOther>& o)
-  : SE3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const Eigen::Quaternion<Scalar>& q)
+SE3<_Scalar>::SE3(const Translation& t, const Eigen::Quaternion<Scalar>& q)
   : SE3((DataType() << t, q.coeffs() ).finished())
 {
   //
 }
 
 template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const Eigen::AngleAxis<Scalar>& a)
+SE3<_Scalar>::SE3(const Translation& t, const Eigen::AngleAxis<Scalar>& a)
   : SE3(t, Quaternion(a))
 {
   //
@@ -206,16 +173,15 @@ template <typename _Scalar>
 SE3<_Scalar>::SE3(const Scalar x, const Scalar y, const Scalar z,
                   const Scalar roll, const Scalar pitch, const Scalar yaw)
   : SE3(Translation(x,y,z), Eigen::Quaternion<Scalar>(
-          Eigen::AngleAxis<Scalar>(yaw,   Eigen::Matrix<Scalar, 3, 1>::UnitZ()) *
-          Eigen::AngleAxis<Scalar>(pitch, Eigen::Matrix<Scalar, 3, 1>::UnitY()) *
-          Eigen::AngleAxis<Scalar>(roll,  Eigen::Matrix<Scalar, 3, 1>::UnitX())  ))
+      Eigen::AngleAxis<Scalar>(yaw,   Eigen::Matrix<Scalar, 3, 1>::UnitZ()) *
+      Eigen::AngleAxis<Scalar>(pitch, Eigen::Matrix<Scalar, 3, 1>::UnitY()) *
+      Eigen::AngleAxis<Scalar>(roll,  Eigen::Matrix<Scalar, 3, 1>::UnitX())  ))
 {
   //
 }
 
 template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const SO3<Scalar>& so3)
+SE3<_Scalar>::SE3(const Translation& t, const SO3<Scalar>& so3)
   : SE3(t, so3.quat())
 {
   //
@@ -227,7 +193,6 @@ SE3<_Scalar>::SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h)
 {
   //
 }
-
 
 template <typename _Scalar>
 typename SE3<_Scalar>::DataType&

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -78,6 +78,7 @@ public:
   ~SE3() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE3)
+  MANIF_MOVE_CONSTRUCTOR(SE3)
 
   template <typename _DerivedOther>
   SE3(const LieGroupBase<_DerivedOther>& o);

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se3/SE3_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 
 // Forward declare for type traits specialization

--- a/include/manif/impl/se3/SE3Tangent.h
+++ b/include/manif/impl/se3/SE3Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SE3TangentBase<SE3Tangent<_Scalar>>;
   using Type = SE3Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SE3Tangent()  = default;
   ~SE3Tangent() = default;
 
-  // Copy constructor given base
-  SE3Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SE3Tangent(const SE3TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE3Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SE3Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE3Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SE3Tangent)
 
   // Tangent common API
 
@@ -87,35 +87,10 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SE3Tangent);
 
 template <typename _Scalar>
-SE3Tangent<_Scalar>::SE3Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE3Tangent<_Scalar>::SE3Tangent(
-    const SE3TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
 SE3Tangent<_Scalar>::SE3Tangent(
     const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE3Tangent<_Scalar>::SE3Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/se3/SE3Tangent.h
+++ b/include/manif/impl/se3/SE3Tangent.h
@@ -63,6 +63,7 @@ public:
   ~SE3Tangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE3Tangent)
+  MANIF_MOVE_CONSTRUCTOR(SE3Tangent)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/se3/SE3Tangent.h
+++ b/include/manif/impl/se3/SE3Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se3/SE3Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -36,8 +36,15 @@ public:
   using Base::data;
   using Base::coeffs;
 
-  SE3TangentBase()  = default;
-  ~SE3TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE3TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SE3TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/se3/SE3Tangent_map.h
+++ b/include/manif/impl/se3/SE3Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SE3Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -5,8 +5,6 @@
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/so3/SO3_map.h"
 
-#include <Eigen/Geometry>
-
 namespace manif {
 
 //

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -470,10 +470,10 @@ struct AssignmentEvaluatorImpl<SE3Base<Derived>>
   {
     using std::abs;
     using Scalar = typename SE3Base<Derived>::Scalar;
-    MANIF_CHECK(abs(data.template tail<4>().norm()-Scalar(1)) <
-                Constants<Scalar>::eps_s,
-                "SE3 assigned data not normalized !",
-                invalid_argument);
+    MANIF_ASSERT(abs(data.template tail<4>().norm()-Scalar(1)) <
+                 Constants<Scalar>::eps_s,
+                 "SE3 assigned data not normalized !",
+                 manif::invalid_argument);
   }
 };
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -42,6 +42,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE3Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SE3Base)
+
   /**
    * @brief Get the inverse.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -393,6 +403,22 @@ struct RandomEvaluatorImpl<SE3Base<Derived>>
                  Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
 
     //m = Derived(Translation::Random(), Quaternion::UnitRandom());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SE3Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SE3Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.template tail<4>().norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "SE3 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/se3/SE3_map.h
+++ b/include/manif/impl/se3/SE3_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SE3)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se_2_3/SE_2_3.h
+++ b/include/manif/impl/se_2_3/SE_2_3.h
@@ -78,6 +78,7 @@ public:
   ~SE_2_3() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE_2_3)
+  MANIF_MOVE_CONSTRUCTOR(SE_2_3)
 
   template <typename _DerivedOther>
   SE_2_3(const LieGroupBase<_DerivedOther>& o);

--- a/include/manif/impl/se_2_3/SE_2_3.h
+++ b/include/manif/impl/se_2_3/SE_2_3.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se_2_3/SE_2_3_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 
 // Forward declare for type traits specialization
@@ -59,35 +57,32 @@ private:
   using Base = SE_2_3Base<SE_2_3<_Scalar>>;
   using Type = SE_2_3<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
 
   MANIF_COMPLETE_GROUP_TYPEDEF
   using Translation = typename Base::Translation;
-  using Quaternion = Eigen::Quaternion<Scalar>;
+  using Quaternion  = Eigen::Quaternion<Scalar>;
   using LinearVelocity = typename Base::LinearVelocity;
 
   MANIF_INHERIT_GROUP_API
-//   using Base::transform;
   using Base::rotation;
   using Base::normalize;
 
   SE_2_3()  = default;
   ~SE_2_3() = default;
 
-  // Copy constructor given base
-  SE_2_3(const Base& o);
-
-  template <typename _DerivedOther>
-  SE_2_3(const SE_2_3Base<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE_2_3)
 
   template <typename _DerivedOther>
   SE_2_3(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE_2_3(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SE_2_3)
 
   /**
    * @brief Constructor given a translation, a unit quaternion and a linear velocity.
@@ -158,34 +153,6 @@ protected:
 };
 
 MANIF_EXTRA_GROUP_TYPEDEF(SE_2_3)
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE_2_3<_Scalar>::SE_2_3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.template segment<4>(3).norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "SE_2_3 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SE_2_3<_Scalar>::SE_2_3(const Base& o)
-  : SE_2_3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE_2_3<_Scalar>::SE_2_3(
-    const SE_2_3Base<_DerivedOther>& o)
-  : SE_2_3(o.coeffs())
-{
-  //
-}
 
 template <typename _Scalar>
 template <typename _DerivedOther>

--- a/include/manif/impl/se_2_3/SE_2_3Tangent.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se_2_3/SE_2_3Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 
@@ -49,6 +47,10 @@ private:
   using Base = SE_2_3TangentBase<SE_2_3Tangent<_Scalar>>;
   using Type = SE_2_3Tangent<_Scalar>;
 
+protected:
+
+    using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +62,12 @@ public:
   SE_2_3Tangent()  = default;
   ~SE_2_3Tangent() = default;
 
-  // Copy constructor given base
-  SE_2_3Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SE_2_3Tangent(const SE_2_3TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE_2_3Tangent)
 
   template <typename _DerivedOther>
   SE_2_3Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE_2_3Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SE_2_3Tangent)
 
   // Tangent common API
 
@@ -87,35 +84,10 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SE_2_3Tangent);
 
 template <typename _Scalar>
-SE_2_3Tangent<_Scalar>::SE_2_3Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE_2_3Tangent<_Scalar>::SE_2_3Tangent(
-    const SE_2_3TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
 SE_2_3Tangent<_Scalar>::SE_2_3Tangent(
     const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE_2_3Tangent<_Scalar>::SE_2_3Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/se_2_3/SE_2_3Tangent.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent.h
@@ -63,6 +63,7 @@ public:
   ~SE_2_3Tangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(SE_2_3Tangent)
+  MANIF_MOVE_CONSTRUCTOR(SE_2_3Tangent)
 
   template <typename _DerivedOther>
   SE_2_3Tangent(const TangentBase<_DerivedOther>& o);

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
@@ -26,6 +26,7 @@ private:
 public:
 
   MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
   MANIF_INHERIT_TANGENT_OPERATOR
 
   using BlockV = typename DataType::template FixedSegmentReturnType<3>::Type;
@@ -38,8 +39,15 @@ public:
   using Base::data;
   using Base::coeffs;
 
-  SE_2_3TangentBase()  = default;
-  ~SE_2_3TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE_2_3TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SE_2_3TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_map.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SE_2_3Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -456,10 +456,10 @@ struct AssignmentEvaluatorImpl<SE_2_3Base<Derived>>
   {
     using std::abs;
     using Scalar = typename SE_2_3Base<Derived>::Scalar;
-    MANIF_CHECK(abs(data.template segment<4>(3).norm()-Scalar(1)) <
-                Constants<Scalar>::eps_s,
-                "SE_2_3 assigned data not normalized !",
-                invalid_argument);
+    MANIF_ASSERT(abs(data.template segment<4>(3).norm()-Scalar(1)) <
+                 Constants<Scalar>::eps_s,
+                 "SE_2_3 assigned data not normalized !",
+                 manif::invalid_argument);
   }
 };
 

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -6,8 +6,6 @@
 #include "manif/impl/so3/SO3_map.h"
 #include "manif/impl/se3/SE3_map.h"
 
-#include <Eigen/Geometry>
-
 namespace manif {
 
 //
@@ -53,6 +51,16 @@ public:
   using QuaternionDataType = Eigen::Quaternion<Scalar>;
 
   // LieGroup common API
+
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE_2_3Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SE_2_3Base)
 
   /**
    * @brief Get the inverse.
@@ -436,6 +444,22 @@ struct RandomEvaluatorImpl<SE_2_3Base<Derived>>
     m = LieGroup(Translation::Random(),
                  Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)),
                  LinearVelocity::Random());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SE_2_3Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SE_2_3Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.template segment<4>(3).norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "SE_2_3 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/se_2_3/SE_2_3_map.h
+++ b/include/manif/impl/se_2_3/SE_2_3_map.h
@@ -46,10 +46,11 @@ public:
 
   MANIF_COMPLETE_GROUP_TYPEDEF
   MANIF_INHERIT_GROUP_API
-//   using Base::transform;
   using Base::rotation;
 
   Map(Scalar* coeffs) : data_(coeffs) { }
+
+  MANIF_GROUP_MAP_ASSIGN_OP(SE_2_3)
 
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
@@ -72,7 +73,6 @@ public:
 
   MANIF_COMPLETE_GROUP_TYPEDEF
   MANIF_INHERIT_GROUP_API
-//   using Base::transform;
   using Base::rotation;
 
   Map(const Scalar* coeffs) : data_(coeffs) { }

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -63,21 +63,22 @@ public:
   using Base::rotation;
   using Base::normalize;
 
+protected:
+
+  using Base::derived;
+
+public:
+
   SO2()  = default;
   ~SO2() = default;
 
+  MANIF_COPY_CONSTRUCTOR(SO2)
+
   // Copy constructor given base
-  SO2(const Base& o);
-
-  template <typename _DerivedOther>
-  SO2(const SO2Base<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   SO2(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO2(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SO2)
 
   /**
    * @brief Constructor given the real and imaginary part
@@ -109,36 +110,8 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO2)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SO2<_Scalar>::SO2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-               "SO2 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SO2<_Scalar>::SO2(const Base& o)
-  : SO2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO2<_Scalar>::SO2(
-    const SO2Base<_DerivedOther>& o)
-  : SO2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO2<_Scalar>::SO2(
-    const LieGroupBase<_DerivedOther>& o)
+SO2<_Scalar>::SO2(const LieGroupBase<_DerivedOther>& o)
   : SO2(o.coeffs())
 {
   //

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -73,6 +73,7 @@ public:
   ~SO2() = default;
 
   MANIF_COPY_CONSTRUCTOR(SO2)
+  MANIF_MOVE_CONSTRUCTOR(SO2)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/so2/SO2Tangent.h
+++ b/include/manif/impl/so2/SO2Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/so2/SO2Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/so2/SO2Tangent.h
+++ b/include/manif/impl/so2/SO2Tangent.h
@@ -61,6 +61,7 @@ public:
   ~SO2Tangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(SO2Tangent)
+  MANIF_MOVE_CONSTRUCTOR(SO2Tangent)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/so2/SO2Tangent.h
+++ b/include/manif/impl/so2/SO2Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SO2TangentBase<SO2Tangent<_Scalar>>;
   using Type = SO2Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_TANGENT_TYPEDEF
@@ -58,17 +62,13 @@ public:
   SO2Tangent()  = default;
   ~SO2Tangent() = default;
 
-  // Copy constructor given base
-  SO2Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SO2Tangent(const SO2TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SO2Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SO2Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO2Tangent(const Eigen::MatrixBase<_EigenDerived>& theta);
+  MANIF_TANGENT_ASSIGN_OP(SO2Tangent)
 
   //! @brief Constructor given an angle (rad.).
   SO2Tangent(const Scalar theta);
@@ -90,25 +90,8 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SO2Tangent);
 
 template <typename _Scalar>
-SO2Tangent<_Scalar>::SO2Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const SO2TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const TangentBase<_DerivedOther>& o)
+SO2Tangent<_Scalar>::SO2Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
 {
   //
@@ -116,15 +99,6 @@ SO2Tangent<_Scalar>::SO2Tangent(
 
 template <typename _Scalar>
 SO2Tangent<_Scalar>::SO2Tangent(const Scalar theta)
-  : data_(theta)
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& theta)
   : data_(theta)
 {
   //

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -29,8 +29,15 @@ public:
 
   using Base::coeffs;
 
-  SO2TangentBase()  = default;
-  ~SO2TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO2TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SO2TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/so2/SO2Tangent_map.h
+++ b/include/manif/impl/so2/SO2Tangent_map.h
@@ -48,6 +48,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SO2Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -331,9 +331,9 @@ struct AssignmentEvaluatorImpl<SO2Base<Derived>>
   {
     using std::abs;
     using Scalar = typename SO2Base<Derived>::Scalar;
-    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-                "SO2 assigned data not normalized !",
-                invalid_argument);
+    MANIF_ASSERT(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                 "SO2 assigned data not normalized !",
+                 invalid_argument);
   }
 };
 

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -35,6 +35,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO2Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SO2Base)
+
   /**
    * @brief Get the inverse of this.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -309,6 +319,21 @@ struct RandomEvaluatorImpl<SO2Base<Derived>>
   {
     using Tangent = typename LieGroupBase<Derived>::Tangent;
     m = Tangent::Random().exp();
+  }
+};
+
+//! @brief Assignment assert specialization for SO2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SO2Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SO2Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                "SO2 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/so2/SO2_map.h
+++ b/include/manif/impl/so2/SO2_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SO2)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -76,6 +76,7 @@ public:
   ~SO3() = default;
 
   MANIF_COPY_CONSTRUCTOR(SO3)
+  MANIF_MOVE_CONSTRUCTOR(SO3)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -57,6 +57,10 @@ private:
 
   using QuaternionDataType = Eigen::Quaternion<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -71,18 +75,13 @@ public:
   SO3()  = default;
   ~SO3() = default;
 
+  MANIF_COPY_CONSTRUCTOR(SO3)
+
   // Copy constructor given base
-  SO3(const Base& o);
-
-  template <typename _DerivedOther>
-  SO3(const SO3Base<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   SO3(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO3(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SO3)
 
   /**
    * @brief Constructor given a unit quaternion.
@@ -124,42 +123,12 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO3)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-               "SO3 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SO3<_Scalar>::SO3(const Base& o)
-  : SO3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO3<_Scalar>::SO3(
-    const SO3Base<_DerivedOther>& o)
+SO3<_Scalar>::SO3(const LieGroupBase<_DerivedOther>& o)
   : SO3(o.coeffs())
 {
   //
 }
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO3<_Scalar>::SO3(
-    const LieGroupBase<_DerivedOther>& o)
-  : SO3(o.coeffs())
-{
-  //
-}
-
-
 
 template <typename _Scalar>
 SO3<_Scalar>::SO3(const QuaternionDataType& q)

--- a/include/manif/impl/so3/SO3Tangent.h
+++ b/include/manif/impl/so3/SO3Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/so3/SO3Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/so3/SO3Tangent.h
+++ b/include/manif/impl/so3/SO3Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SO3TangentBase<SO3Tangent<_Scalar>>;
   using Type = SO3Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SO3Tangent()  = default;
   ~SO3Tangent() = default;
 
-  // Copy constructor given base
-  SO3Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SO3Tangent(const SO3TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SO3Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SO3Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO3Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SO3Tangent)
 
   // Tangent common API
 
@@ -87,35 +87,9 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SO3Tangent);
 
 template <typename _Scalar>
-SO3Tangent<_Scalar>::SO3Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const SO3TangentBase<_DerivedOther>& o)
+SO3Tangent<_Scalar>::SO3Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/so3/SO3Tangent.h
+++ b/include/manif/impl/so3/SO3Tangent.h
@@ -63,6 +63,7 @@ public:
   ~SO3Tangent() = default;
 
   MANIF_COPY_CONSTRUCTOR(SO3Tangent)
+  MANIF_MOVE_CONSTRUCTOR(SO3Tangent)
 
   // Copy constructor given base
   template <typename _DerivedOther>

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -31,8 +31,15 @@ public:
 
   using Base::coeffs;
 
-  SO3TangentBase()  = default;
-  ~SO3TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO3TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SO3TangentBase)
 
   /**
    * @brief Hat operator of SO3.

--- a/include/manif/impl/so3/SO3Tangent_map.h
+++ b/include/manif/impl/so3/SO3Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SO3Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -400,9 +400,9 @@ struct AssignmentEvaluatorImpl<SO3Base<Derived>>
   {
     using std::abs;
     using Scalar = typename SO3Base<Derived>::Scalar;
-    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-                "SO3 assigned data not normalized !",
-                invalid_argument);
+    MANIF_ASSERT(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                 "SO3 assigned data not normalized !",
+                 manif::invalid_argument);
   }
 };
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -35,6 +35,16 @@ public:
   using Transformation = typename internal::traits<_Derived>::Transformation;
   using QuaternionDataType = Eigen::Quaternion<Scalar>;
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO3Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SO3Base)
+
   // LieGroup common API
 
   /**
@@ -378,6 +388,21 @@ struct RandomEvaluatorImpl<SO3Base<Derived>>
 
 
     // m = Derived(Quaternion::UnitRandom());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SO3Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SO3Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                "SO3 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/so3/SO3_map.h
+++ b/include/manif/impl/so3/SO3_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SO3)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so3/SO3_map.h
+++ b/include/manif/impl/so3/SO3_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  Map(Map&&) = default;
+
   MANIF_GROUP_MAP_ASSIGN_OP(SO3)
 
   DataType& coeffs() { return data_; }
@@ -78,6 +80,8 @@ public:
   using Base::rotation;
 
   Map(const Scalar* coeffs) : data_(coeffs) { }
+
+  Map(Map&&) = default;
 
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -39,10 +39,35 @@ struct TangentBase
   template <typename _Scalar>
   using TangentTemplate = typename internal::traitscast<Tangent, _Scalar>::cast;
 
+protected:
+
+  MANIF_DEFAULT_CONSTRUCTOR(TangentBase)
+
 public:
 
-  TangentBase()  = default;
-  ~TangentBase() = default;
+  /**
+   * @brief Assignment operator.
+   * @param[in] t An element of the same Tangent group.
+   * @return A reference to this.
+   */
+  _Derived& operator =(const TangentBase& t);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] t An element of the same Tangent group.
+   * @return A reference to this.
+   */
+  template <typename _DerivedOther>
+  _Derived& operator =(const TangentBase<_DerivedOther>& t);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] t A DataType object.
+   * @return A reference to this.
+   * @see DataType.
+   */
+  template <typename _EigenDerived>
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
 
   //! @brief Access the underlying data by reference
   DataType& coeffs();
@@ -258,30 +283,6 @@ public:
 
   // Copy assignment
 
-  /**
-   * @brief Assignment operator.
-   * @param[in] t An element of the same Tangent group.
-   * @return A reference to this.
-   */
-  _Derived& operator =(const TangentBase<_Derived>& t);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] t An element of the same Tangent group.
-   * @return A reference to this.
-   */
-  template <typename _DerivedOther>
-  _Derived& operator =(const TangentBase<_DerivedOther>& t);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] t A DataType object.
-   * @return A reference to this.
-   * @see DataType.
-   */
-  template <typename _EigenDerived>
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
-
   template <typename T>
   auto operator <<(T&& v)
   ->decltype( std::declval<DataType>().operator<<(std::forward<T>(v)) );
@@ -332,11 +333,39 @@ public:
   //! Static helper to get a Basis of the Lie group.
   static InnerWeight W();
 
-private:
+protected:
 
-  _Derived& derived() { return *static_cast< _Derived* >(this); }
-  const _Derived& derived() const { return *static_cast< const _Derived* >(this); }
+  inline _Derived& derived() & noexcept { return *static_cast< _Derived* >(this); }
+  inline const _Derived& derived() const & noexcept { return *static_cast< const _Derived* >(this); }
 };
+
+// Copy
+
+template <typename _Derived>
+_Derived&
+TangentBase<_Derived>::operator =(const TangentBase& t)
+{
+  coeffs() = t.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+_Derived&
+TangentBase<_Derived>::operator =(const TangentBase<_DerivedOther>& t)
+{
+  coeffs() = t.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+_Derived&
+TangentBase<_Derived>::operator =(const Eigen::MatrixBase<_EigenDerived>& v)
+{
+  coeffs() = v;
+  return derived();
+}
 
 template <typename _Derived>
 typename TangentBase<_Derived>::DataType&
@@ -604,36 +633,6 @@ bool TangentBase<_Derived>::isApprox(
 }
 
 // Operators
-
-// Copy assignment
-
-template <typename _Derived>
-_Derived&
-TangentBase<_Derived>::operator =(
-    const TangentBase<_Derived>& t)
-{
-  coeffs() = t.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _DerivedOther>
-_Derived&
-TangentBase<_Derived>::operator =(
-    const TangentBase<_DerivedOther>& t)
-{
-  coeffs() = t.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _EigenDerived>
-_Derived& TangentBase<_Derived>::operator =(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-{
-  coeffs() = v;
-  return derived();
-}
 
 template <typename _Derived>
 template <typename T>

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -2,15 +2,22 @@
 #define _MANIF_MANIF_TEST_COMMON_TESTER_H_
 
 #include "test_utils.h"
+#include "test_func.h"
 #include "manif/algorithms/interpolation.h"
 #include "manif/algorithms/average.h"
 
 #define MANIF_TEST(manifold)                                              \
   using TEST_##manifold##_TESTER = CommonTester<manifold>;                \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MISC)                \
+  { evalMisc(); }                                                         \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_COPY_CONSTRUCTOR)    \
-  { evalCopyConstructor(); }                                \
+  { evalCopyConstructor(); }                                              \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MOVE_CONSTRUCTOR)    \
+  { evalMoveConstructor(); }                                              \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_ASSIGNMENT)          \
   { evalAssignment(); }                                                   \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MOVE_ASSIGNMENT)     \
+  { evalMoveAssignment(); }                                               \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_DATA_PTR_VALID)      \
   { evalDataPtrValid(); }                                                 \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_IS_RPLUS)       \
@@ -107,15 +114,17 @@
   TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_MINUS_T_JACOBIANS) \
   { evalTanMinusTanJac(); }
 
-#define MANIF_TEST_MAP(manifold)                                       \
-  using TEST_##manifold##_MAP_TESTER = CommonMapTester<manifold>;      \
-  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_DATA_PTR)     \
-  { evalDataPtr(); }                                                   \
-  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_ASSIGN_OP)    \
-  { evalAssignOp(); }                                                  \
-  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_SET_RANDOM)   \
-  { evalSetRandom(); }                                                 \
-  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_SET_IDENTITY) \
+#define MANIF_TEST_MAP(manifold)                                          \
+  using TEST_##manifold##_MAP_TESTER = CommonMapTester<manifold>;         \
+  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_DATA_PTR)        \
+  { evalDataPtr(); }                                                      \
+  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_ASSIGN_OP)       \
+  { evalAssignOp(); }                                                     \
+  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_MOVE_ASSIGN_OP)  \
+  { evalMoveAssignOp(); }                                                 \
+  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_SET_RANDOM)      \
+  { evalSetRandom(); }                                                    \
+  TEST_F(TEST_##manifold##_MAP_TESTER, TEST_##manifold##_SET_IDENTITY)    \
   { evalSetIdentity(); }
 
 
@@ -148,10 +157,28 @@ public:
     delta = Tangent::Random();
   }
 
+  void evalMisc()
+  {
+    if (std::is_nothrow_move_constructible<Scalar>::value)
+    {
+      EXPECT_TRUE(std::is_nothrow_move_constructible<LieGroup>::value)
+        << "LieGroup should be nothrow move constructible";
+      EXPECT_TRUE(std::is_nothrow_move_constructible<Tangent>::value)
+        << "Tangent should be nothrow move constructible";
+    }
+  }
+
   void evalCopyConstructor()
   {
     LieGroup state_copy(state);
     EXPECT_MANIF_NEAR(state, state_copy, tol_);
+  }
+
+  void evalMoveConstructor()
+  {
+    LieGroup state_copy(state);
+    LieGroup state_move(std::move(state));
+    EXPECT_MANIF_NEAR(state_copy, state_move, tol_);
   }
 
   void evalAssignment()
@@ -159,6 +186,46 @@ public:
     LieGroup state_copy;
     state_copy = state;
     EXPECT_MANIF_NEAR(state, state_copy, tol_);
+
+    state_copy = LieGroup::Random();
+    EXPECT_MANIF_NOT_NEAR(state, state_copy, tol_);
+
+    // copy derived to base
+    copy_assign(state_copy, state);
+    EXPECT_MANIF_NEAR(state, state_copy, tol_);
+
+    state_copy = LieGroup::Random();
+    EXPECT_MANIF_NOT_NEAR(state, state_copy, tol_);
+
+    // copy base to base
+    copy_assign_base(state_copy, state);
+    EXPECT_MANIF_NEAR(state, state_copy, tol_);
+  }
+
+  void evalMoveAssignment()
+  {
+    LieGroup state_copy(state);
+    LieGroup state_move = LieGroup::Random();
+    state_move = std::move(state);
+    EXPECT_MANIF_NEAR(state_copy, state_move, tol_);
+
+    state_move = LieGroup::Random();
+    EXPECT_MANIF_NOT_NEAR(state_copy, state_move, tol_);
+    state = state_copy;
+    EXPECT_MANIF_NEAR(state_copy, state, tol_);
+
+    // move derived to base
+    move_assign(state_move, state);
+    EXPECT_MANIF_NEAR(state_copy, state_move, tol_);
+
+    state_move = LieGroup::Random();
+    EXPECT_MANIF_NOT_NEAR(state, state_move, tol_);
+    state = state_copy;
+    EXPECT_MANIF_NEAR(state_copy, state, tol_);
+
+    // move base to base
+    move_assign_base(state_move, state);
+    EXPECT_MANIF_NEAR(state_copy, state_move, tol_);
   }
 
   void evalDataPtrValid()
@@ -1015,6 +1082,8 @@ public:
     ASSERT_EIGEN_NEAR(state_data, state_map.coeffs());
     ASSERT_EIGEN_NEAR(state_other_data, state_other_map.coeffs());
     ASSERT_EIGEN_NEAR(delta_data, delta_map.coeffs());
+
+    ASSERT_EIGEN_NOT_NEAR(state_data, state_other_data);
   }
 
   void evalDataPtr()
@@ -1039,6 +1108,21 @@ public:
     state_map = state_other_map;
 
     EXPECT_EIGEN_NEAR(state_other_data, state_data);
+  }
+
+  void evalMoveAssignOp()
+  {
+    const Scalar* data_ptr = state_map.data();
+    const Scalar* other_data_ptr = state_other_map.data();
+
+    ASSERT_NE(data_ptr, other_data_ptr);
+
+    state_map = std::move(state_other_map);
+
+    EXPECT_EIGEN_NEAR(state_other_data, state_map.coeffs());
+
+    EXPECT_EQ(data_ptr, state_data.data());
+    EXPECT_NE(other_data_ptr, state_data.data());
   }
 
   void evalSetRandom()

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -205,8 +205,7 @@ public:
   void evalMoveAssignment()
   {
     LieGroup state_copy(state);
-    LieGroup state_move = LieGroup::Random();
-    state_move = std::move(state);
+    LieGroup state_move = std::move(state);
     EXPECT_MANIF_NEAR(state_copy, state_move, tol_);
 
     state_move = LieGroup::Random();

--- a/test/eigen_gtest.h
+++ b/test/eigen_gtest.h
@@ -2,7 +2,6 @@
 #define _MANIF_TEST_EIGEN_GTEST_H_
 
 #include <gtest/gtest.h>
-#include <Eigen/Dense>
 
 namespace manif {
 namespace detail {

--- a/test/eigen_gtest.h
+++ b/test/eigen_gtest.h
@@ -271,6 +271,19 @@ inline ::testing::AssertionResult isEigenMatrixNear(const Eigen::MatrixBase<_Der
 #define ASSERT_EIGEN_NEAR(...) \
   __ASSERT_EIGEN_NEAR_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
 
+#define ASSERT_EIGEN_NOT_NEAR_DEFAULT_TOL(A,B) \
+  ASSERT_FALSE(manif::isEigenMatrixNear(A, B, #A, #B))
+
+#define ASSERT_EIGEN_NOT_NEAR_TOL(A,B,tol) \
+  ASSERT_FALSE(manif::isEigenMatrixNear(A, B, #A, #B, tol))
+
+#define __ASSERT_EIGEN_NOT_NEAR_CHOOSER(...) \
+  __GET_4TH_ARG(__VA_ARGS__, ASSERT_EIGEN_NOT_NEAR_TOL, \
+                ASSERT_EIGEN_NOT_NEAR_DEFAULT_TOL, )
+
+#define ASSERT_EIGEN_NOT_NEAR(...) \
+  __ASSERT_EIGEN_NOT_NEAR_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
+
 /*
  * E.g
 

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -3,8 +3,6 @@
 #include "manif/SE3.h"
 #include "../common_tester.h"
 
-#include <Eigen/Geometry>
-
 using namespace manif;
 
 TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_DATATYPE)
@@ -234,7 +232,7 @@ TEST(TEST_SE3, TEST_SE3_INVERSE)
 
   se3 = SE3d::Random();
 
-  Eigen::Isometry3d iso(se3.asSO3().quat());
+  Eigen::Isometry3d iso(se3.quat());
   iso.translation() = se3.translation();
 
   EXPECT_EIGEN_NEAR(iso.matrix(), se3.transform());

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -349,8 +349,6 @@ TEST(TEST_SO2, TEST_SO2_COMPOSE_JAC)
   SO2d::Jacobian J_c_a, J_c_b;
   SO2d so2c = so2a.compose(so2b, J_c_a, J_c_b);
 
-  so2c = so2a.compose(so2b, SO2d::_, J_c_b);
-
   EXPECT_DOUBLE_EQ(MANIF_PI, so2c.angle());
 
   EXPECT_EQ(1, J_c_a.rows());

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -149,7 +149,7 @@ TEST(TEST_SO3, TEST_SO3_ROTATION)
 
 TEST(TEST_SO3, TEST_SO3_ASSIGN_OP)
 {
-  SO3d so3a = SO3d::Random();
+  SO3d so3a;
   SO3d so3b = SO3d::Random();
 
   so3a = so3b;

--- a/test/test_func.h
+++ b/test/test_func.h
@@ -1,0 +1,38 @@
+#ifndef _MANIF_MANIF_TEST_FUNCTIONS_H_
+#define _MANIF_MANIF_TEST_FUNCTIONS_H_
+
+#include "manif/impl/lie_group_base.h"
+
+namespace manif {
+
+template <typename _Derived, typename _Other>
+void copy_assign(LieGroupBase<_Derived>& state,
+                 const _Other& state_other)
+{
+  state = state_other;
+}
+
+template <typename _Derived, typename _DerivedOther>
+void copy_assign_base(LieGroupBase<_Derived>& state,
+                      const LieGroupBase<_DerivedOther>& state_other)
+{
+  state = state_other;
+}
+
+template <typename _Derived, typename _Other>
+void move_assign(LieGroupBase<_Derived>& state,
+                 _Other& state_other)
+{
+  state = std::move(state_other);
+}
+
+template <typename _Derived, typename _DerivedOther>
+void move_assign_base(LieGroupBase<_Derived>& state,
+                      LieGroupBase<_DerivedOther>& state_other)
+{
+  state = std::move(state_other);
+}
+
+} // namespace manif
+
+#endif // _MANIF_MANIF_TEST_FUNCTIONS_H_


### PR DESCRIPTION
- Fix compilation warning in `lt::optional`
- Review all of the constructors and copy/move assignment (fixing a lot of warnings)
- Cleanup Eigen includes
- Add g++8/9 to CI

g++8/9 were issuing a lot of warnings concerning copy constructors and assignment due to implicit default being hidden in derived classes and such. This PR fixes that and (hopefully) brings some order in this matter. Some of the boilerplate code related to constructor/assignment is factored away in macros. 

Replaces #140 and #141 and #173. 

Closes #139
Closes #162
Closes #170
Closes #172