### PR TITLE
Add option to limit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -289,7 +289,7 @@ matrix:
     arch: arm64
     compiler: gcc
     script:
-      - cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON -DLIMIT_TESTS=ON ..
       - make
       - make test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,10 @@ endif()
 
 if(BUILD_TESTING)
 
+  if(LIMIT_TESTS)
+    add_definitions(-DMANIF_LIMIT_TESTS)
+  endif()
+
   enable_testing()
   add_subdirectory(test)
 

--- a/test/rn/gtest_rn.cpp
+++ b/test/rn/gtest_rn.cpp
@@ -14,9 +14,10 @@ using namespace manif;
 // especially, SO3 wasn't an issue despite being Eigen::Vector4d too...
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(R4d)
 
-#ifdef MANIF_COVERAGE_ENABLED
+#if defined(MANIF_COVERAGE_ENABLED) || defined(MANIF_LIMIT_TESTS)
 
 MANIF_TEST(R4d);
+MANIF_TEST_MAP(R4d);
 MANIF_TEST_JACOBIANS(R4d);
 
 #else


### PR DESCRIPTION
Compiling the `Rn` test suite often hangs in CI on arm64 - it is a rather heavy suite... This PR introduces an option to limit the `Rn` tests to a bare minimum and enables it in the arm64 job.