### PR TITLE
Increase CI timeout on arm64 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,8 +290,8 @@ matrix:
     compiler: gcc
     script:
       - cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
-      - make
-      - make test
+      - travis_wait make
+      - travis_wait make test
 
   #
   # Ceres-related tests


### PR DESCRIPTION
Compiling the Rn test suite often hangs in CI on arm64 - it is a rather heavy suite... This PR [increases the arm64 job timeout](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) (no log received for more than 10min).

Replaces #155.