### PR TITLE
Add unit dual quaternion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,24 @@ matrix:
       - make test
 
   #
+  # G++ 8
+  #
+  - os: linux
+    env:
+      - TEST="G++ 8"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+          - g++-8
+    script:
+      - cmake -DCMAKE_CXX_COMPILER="g++-8" -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - make
+      - make test
+
+  #
   # G++ 9
   #
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,24 @@ matrix:
       - make test
 
   #
+  # G++ 9
+  #
+  - os: linux
+    env:
+      - TEST="G++ 9"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-9
+          - g++-9
+    script:
+      - cmake -DCMAKE_CXX_COMPILER="g++-9" -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ..
+      - make
+      - make test
+
+  #
   # Clang 3.8
   #
   - os: linux

--- a/examples/se2_localization.cpp
+++ b/examples/se2_localization.cpp
@@ -103,8 +103,6 @@
 
 #include "manif/SE2.h"
 
-#include <Eigen/Dense>
-
 #include <vector>
 
 #include <iostream>

--- a/examples/se2_sam.cpp
+++ b/examples/se2_sam.cpp
@@ -180,9 +180,6 @@
 // manif
 #include "manif/SE2.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/examples/se3_localization.cpp
+++ b/examples/se3_localization.cpp
@@ -103,8 +103,6 @@
 
 #include "manif/SE3.h"
 
-#include <Eigen/Dense>
-
 #include <vector>
 
 #include <iostream>

--- a/examples/se3_sam.cpp
+++ b/examples/se3_sam.cpp
@@ -180,9 +180,6 @@
 // manif
 #include "manif/SE3.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/examples/se3_sam_selfcalib.cpp
+++ b/examples/se3_sam_selfcalib.cpp
@@ -182,9 +182,6 @@
 // manif
 #include "manif/SE3.h"
 
-// Eigen
-#include <Eigen/Dense>
-
 // Std
 #include <vector>
 #include <map>

--- a/external/lt/lt/optional.hpp
+++ b/external/lt/lt/optional.hpp
@@ -391,7 +391,8 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
   using optional_operations_base<T>::optional_operations_base;
 
   optional_copy_base() = default;
-  optional_copy_base(const optional_copy_base &rhs) {
+  optional_copy_base(const optional_copy_base &rhs)
+    : optional_operations_base<T>() {
     if (rhs.has_value()) {
       this->construct(rhs.get());
     } else {

--- a/include/manif/DHu.h
+++ b/include/manif/DHu.h
@@ -1,0 +1,16 @@
+#ifndef _MANIF_DHU_H_
+#define _MANIF_DHU_H_
+
+#include "manif/impl/macro.h"
+#include "manif/impl/lie_group_base.h"
+#include "manif/impl/tangent_base.h"
+
+#include "manif/impl/dhu/DHu_properties.h"
+#include "manif/impl/dhu/DHu_base.h"
+#include "manif/impl/dhu/DHuTangent_base.h"
+#include "manif/impl/dhu/DHu.h"
+#include "manif/impl/dhu/DHuTangent.h"
+#include "manif/impl/dhu/DHu_map.h"
+#include "manif/impl/dhu/DHuTangent_map.h"
+
+#endif // _MANIF_DHU_H_

--- a/include/manif/impl/assignment_assert.h
+++ b/include/manif/impl/assignment_assert.h
@@ -1,0 +1,24 @@
+#ifndef _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_
+#define _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_
+
+namespace manif {
+namespace internal {
+
+template <typename Derived>
+struct AssignmentEvaluatorImpl
+{
+  template <typename T> static void run_impl(const T&) { }
+};
+
+template <typename Derived>
+struct AssignmentEvaluator : AssignmentEvaluatorImpl<Derived>
+{
+  using Base = AssignmentEvaluatorImpl<Derived>;
+
+  template <typename T> void run(T&& t) { Base::run_impl(std::forward<T>(t)); }
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_IMPL_ASSIGNMENT_ASSERT_H_

--- a/include/manif/impl/dhu/DHu.h
+++ b/include/manif/impl/dhu/DHu.h
@@ -1,0 +1,227 @@
+#ifndef _MANIF_MANIF_DHU_H_
+#define _MANIF_MANIF_DHU_H_
+
+#include "manif/impl/dhu/DHu_base.h"
+
+namespace manif {
+
+// Forward declare for type traits specialization
+
+template <typename _Scalar> struct DHu;
+template <typename _Scalar> struct DHuTangent;
+
+namespace internal {
+
+//! Traits specialization
+template <typename _Scalar>
+struct traits<DHu<_Scalar>>
+{
+  using Scalar = _Scalar;
+
+  using LieGroup = DHu<_Scalar>;
+  using Tangent  = DHuTangent<_Scalar>;
+
+  using Base = DHuBase<DHu<_Scalar>>;
+
+  static constexpr int Dim = LieGroupProperties<Base>::Dim;
+  static constexpr int DoF = LieGroupProperties<Base>::DoF;
+  static constexpr int RepSize = 8;
+
+  using DataType = Eigen::Matrix<Scalar, RepSize, 1>;
+
+  using Jacobian       = Eigen::Matrix<Scalar, DoF, DoF>;
+  using Transformation = Eigen::Matrix<Scalar, 4, 4>;
+  using Rotation       = Eigen::Matrix<Scalar, Dim, Dim>;
+  using Translation    = Eigen::Matrix<Scalar, Dim, 1>;
+  using Vector         = Eigen::Matrix<Scalar, Dim, 1>;
+};
+
+} // namespace internal
+} // namespace manif
+
+namespace manif {
+
+//
+// LieGroup
+//
+
+/**
+ * @brief Represent an element of DHu.
+ */
+template <typename _Scalar>
+struct DHu : DHuBase<DHu<_Scalar>>
+{
+private:
+
+  using Base = DHuBase<DHu<_Scalar>>;
+  using Type = DHu<_Scalar>;
+
+protected:
+
+  using Base::derived;
+
+public:
+
+  MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
+
+  MANIF_COMPLETE_GROUP_TYPEDEF
+  using Translation = typename Base::Translation;
+  using Quaternion = Eigen::Quaternion<Scalar>;
+  using Real = Quaternion;
+  using Dual = Quaternion;
+
+  MANIF_INHERIT_GROUP_API
+  using Base::transform;
+  using Base::rotation;
+  using Base::normalize;
+
+  DHu()  = default;
+  ~DHu() = default;
+
+  MANIF_COPY_CONSTRUCTOR(DHu)
+
+  template <typename _DerivedOther>
+  DHu(const LieGroupBase<_DerivedOther>& o);
+
+  MANIF_GROUP_ASSIGN_OP(DHu)
+
+  /**
+   * @brief Constructor given a translation and a unit quaternion.
+   * @param[in] t A translation vector.
+   * @param[in] q A unit quaternion.
+   * @throws manif::invalid_argument on un-normalized complex number.
+   */
+  DHu(const Real& real, const Dual& dual);
+
+  /**
+   * @brief Constructor given a translation and a unit quaternion.
+   * @param[in] t A translation vector.
+   * @param[in] q A unit quaternion.
+   * @throws manif::invalid_argument on un-normalized complex number.
+   */
+  // DHu(const Translation& t,
+  //     const Eigen::Quaternion<Scalar>& q);
+
+  /**
+   * @brief Constructor given a translation and an angle axis.
+   * @param[in] t A translation vector.
+   * @param[in] angle_axis An angle-axis.
+   */
+  // DHu(const Translation& t,
+  //     const Eigen::AngleAxis<Scalar>& angle_axis);
+
+  /**
+   * @brief Constructor given a translation and SO3 element.
+   * @param[in] t A translation vector.
+   * @param[in] SO3 An element of SO3.
+   */
+  // DHu(const Translation& t,
+  //     const SO3<Scalar>& SO3);
+
+  /**
+   * @brief Constructor given translation components and
+   * roll-pitch-yaw angles.
+   * @param[in] x The x component of the translation.
+   * @param[in] y The y component of the translation.
+   * @param[in] z The z component of the translation.
+   * @param[in] roll The roll angle.
+   * @param[in] pitch The pitch angle.
+   * @param[in] yaw The yaw angle.
+   */
+  // DHu(const Scalar x, const Scalar y, const Scalar z,
+      // const Scalar roll, const Scalar pitch, const Scalar yaw);
+
+  /**
+   * @brief Constructor from a 3D Eigen::Isometry<Scalar>
+   * @param[in] h an isometry object from Eigen
+   *
+   * Isometry is a typedef from Eigen::Transform, in which the linear part is assumed a rotation matrix.
+   * This is used to speed up certain methods of Transform, especially inverse().
+   */
+  DHu(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h);
+
+  // LieGroup common API
+
+  DataType& coeffs();
+  const DataType& coeffs() const;
+
+  // DHu specific API
+
+protected:
+
+  DataType data_;
+};
+
+MANIF_EXTRA_GROUP_TYPEDEF(DHu)
+
+template <typename _Scalar>
+template <typename _DerivedOther>
+DHu<_Scalar>::DHu(const LieGroupBase<_DerivedOther>& o)
+  : DHu(o.coeffs())
+{
+  //
+}
+
+template <typename _Scalar>
+DHu<_Scalar>::DHu(const Real& real, const Dual& dual)
+  : DHu((DataType() << real.coeffs(), dual.coeffs() ).finished())
+{
+  //
+}
+
+// template <typename _Scalar>
+// DHu<_Scalar>::DHu(const Translation& t, const Eigen::Quaternion<Scalar>& q)
+//   : DHu((DataType() << t, q.coeffs() ).finished())
+// {
+//   //
+// }
+
+// template <typename _Scalar>
+// DHu<_Scalar>::DHu(const Translation& t, const Eigen::AngleAxis<Scalar>& a)
+//   : DHu(t, Quaternion(a))
+// {
+//   //
+// }
+
+// template <typename _Scalar>
+// DHu<_Scalar>::DHu(const Scalar x, const Scalar y, const Scalar z,
+//                   const Scalar roll, const Scalar pitch, const Scalar yaw)
+//   : DHu(Translation(x,y,z), Eigen::Quaternion<Scalar>(
+//       Eigen::AngleAxis<Scalar>(yaw,   Eigen::Matrix<Scalar, 3, 1>::UnitZ()) *
+//       Eigen::AngleAxis<Scalar>(pitch, Eigen::Matrix<Scalar, 3, 1>::UnitY()) *
+//       Eigen::AngleAxis<Scalar>(roll,  Eigen::Matrix<Scalar, 3, 1>::UnitX())  ))
+// {
+//   //
+// }
+
+// template <typename _Scalar>
+// DHu<_Scalar>::DHu(const Translation& t, const SO3<Scalar>& so3)
+//   : DHu(t, so3.quat())
+// {
+//   //
+// }
+
+// template <typename _Scalar>
+// DHu<_Scalar>::DHu(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h)
+//   : DHu(h.translation(), Eigen::Quaternion<_Scalar>(h.rotation()))
+// {
+//   //
+// }
+
+template <typename _Scalar>
+typename DHu<_Scalar>::DataType&
+DHu<_Scalar>::coeffs()
+{
+  return data_;
+}
+
+template <typename _Scalar>
+const typename DHu<_Scalar>::DataType&
+DHu<_Scalar>::coeffs() const
+{
+  return data_;
+}
+
+} // namespace manif
+
+#endif // _MANIF_MANIF_DHU_H_

--- a/include/manif/impl/dhu/DHuTangent.h
+++ b/include/manif/impl/dhu/DHuTangent.h
@@ -1,0 +1,112 @@
+#ifndef _MANIF_MANIF_DHUTANGENT_H_
+#define _MANIF_MANIF_DHUTANGENT_H_
+
+#include "manif/impl/dhu/DHuTangent_base.h"
+
+namespace manif {
+namespace internal {
+
+//! Traits specialization
+template <typename _Scalar>
+struct traits<DHuTangent<_Scalar>>
+{
+  using Scalar = _Scalar;
+
+  using LieGroup = DHu<_Scalar>;
+  using Tangent  = DHuTangent<_Scalar>;
+
+  using Base = DHuTangentBase<Tangent>;
+
+  static constexpr int Dim     = LieGroupProperties<Base>::Dim;
+  static constexpr int DoF     = LieGroupProperties<Base>::DoF;
+  static constexpr int RepSize = DoF;
+
+  using DataType = Eigen::Matrix<Scalar, RepSize, 1>;
+
+  using Jacobian = Eigen::Matrix<Scalar, DoF, DoF>;
+  using LieAlg   = Eigen::Matrix<Scalar, 4, 4>;
+};
+
+} // namespace internal
+} // namespace manif
+
+namespace manif {
+
+//
+// Tangent
+//
+
+/**
+ * @brief Represents an element of tangent space of DHu.
+ */
+template <typename _Scalar>
+struct DHuTangent : DHuTangentBase<DHuTangent<_Scalar>>
+{
+private:
+
+  using Base = DHuTangentBase<DHuTangent<_Scalar>>;
+  using Type = DHuTangent<_Scalar>;
+
+protected:
+
+  using Base::derived;
+
+public:
+
+  MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
+
+  MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
+  MANIF_INHERIT_TANGENT_OPERATOR
+
+  DHuTangent()  = default;
+  ~DHuTangent() = default;
+
+  MANIF_COPY_CONSTRUCTOR(DHuTangent)
+
+  // Copy constructor given base
+  template <typename _DerivedOther>
+  DHuTangent(const TangentBase<_DerivedOther>& o);
+
+  MANIF_TANGENT_ASSIGN_OP(DHuTangent)
+
+  // Tangent common API
+
+  DataType& coeffs();
+  const DataType& coeffs() const;
+
+  // DHuTangent specific API
+
+protected:
+
+  DataType data_;
+};
+
+MANIF_EXTRA_TANGENT_TYPEDEF(DHuTangent);
+
+template <typename _Scalar>
+template <typename _DerivedOther>
+DHuTangent<_Scalar>::DHuTangent(
+    const TangentBase<_DerivedOther>& o)
+  : data_(o.coeffs())
+{
+  //
+}
+
+template <typename _Scalar>
+typename DHuTangent<_Scalar>::DataType&
+DHuTangent<_Scalar>::coeffs()
+{
+  return data_;
+}
+
+template <typename _Scalar>
+const typename DHuTangent<_Scalar>::DataType&
+DHuTangent<_Scalar>::coeffs() const
+{
+  return data_;
+}
+
+} // namespace manif
+
+#endif //_MANIF_MANIF_DHUTANGENT_H_

--- a/include/manif/impl/dhu/DHuTangent_base.h
+++ b/include/manif/impl/dhu/DHuTangent_base.h
@@ -1,0 +1,197 @@
+#ifndef _MANIF_MANIF_DHUTANGENT_BASE_H_
+#define _MANIF_MANIF_DHUTANGENT_BASE_H_
+
+#include "manif/impl/dhu/DHu_properties.h"
+#include "manif/impl/tangent_base.h"
+
+namespace manif {
+
+//
+// Tangent
+//
+
+/**
+ * @brief The base class of the DHu tangent.
+ */
+template <typename _Derived>
+struct DHuTangentBase : TangentBase<_Derived>
+{
+private:
+
+  using Base = TangentBase<_Derived>;
+  using Type = DHuTangentBase<_Derived>;
+
+public:
+
+  MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_OPERATOR
+
+  using Base::data;
+  using Base::coeffs;
+
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(DHuTangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(DHuTangentBase)
+
+  // Tangent common API
+
+  /**
+   * @brief Hat operator of DHu.
+   * @return An element of the Lie algebra dhu.
+   */
+  LieAlg hat() const;
+
+  /**
+   * @brief Get the DHu element.
+   * @param[out] -optional- J_m_t Jacobian of the DHu element wrt this.
+   * @return The DHu element.
+   * @note This is the exp() map with the argument in vector form.
+   */
+  LieGroup exp(OptJacobianRef J_m_t = {}) const;
+
+  /**
+   * @brief This function is deprecated.
+   * Please considere using
+   * @ref exp instead.
+   */
+  MANIF_DEPRECATED
+  LieGroup retract(OptJacobianRef J_m_t = {}) const;
+
+  /**
+   * @brief Get the right Jacobian of DHu.
+   */
+  Jacobian rjac() const;
+
+  /**
+   * @brief Get the left Jacobian of DHu.
+   */
+  Jacobian ljac() const;
+
+  /**
+   * @brief Get the inverse right Jacobian of DHu.
+   */
+  Jacobian rjacinv() const;
+
+  /**
+   * @brief Get the inverse left Jacobian of DHu.
+   */
+  Jacobian ljacinv() const;
+
+  /**
+   * @brief
+   * @return
+   */
+  Jacobian smallAdj() const;
+
+  // DHuTangent specific API
+};
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::LieGroup
+DHuTangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
+{
+  if (J_m_t)
+  {
+    *J_m_t = rjac();
+  }
+
+  // @todo
+  return LieGroup();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::LieGroup
+DHuTangentBase<_Derived>::retract(OptJacobianRef J_m_t) const
+{
+  return exp(J_m_t);
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::LieAlg
+DHuTangentBase<_Derived>::hat() const
+{
+  // @todo
+  return LieAlg();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::Jacobian
+DHuTangentBase<_Derived>::rjac() const
+{
+  // @todo
+  return Jacobian();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::Jacobian
+DHuTangentBase<_Derived>::ljac() const
+{
+  // @todo
+  return Jacobian();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::Jacobian
+DHuTangentBase<_Derived>::rjacinv() const
+{
+  // @todo
+  return Jacobian();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::Jacobian
+DHuTangentBase<_Derived>::ljacinv() const
+{
+  // @todo
+  return Jacobian();
+}
+
+template <typename _Derived>
+typename DHuTangentBase<_Derived>::Jacobian
+DHuTangentBase<_Derived>::smallAdj() const
+{
+  // @todo
+  return Jacobian();
+}
+
+// DHuTangent specific API
+
+namespace internal {
+
+//! @brief Generator specialization for DHuTangentBase objects.
+template <typename Derived>
+struct GeneratorEvaluator<DHuTangentBase<Derived>>
+{
+  static typename DHuTangentBase<Derived>::LieAlg
+  run(const unsigned int i)
+  {
+    using LieAlg = typename DHuTangentBase<Derived>::LieAlg;
+
+    // @todo
+
+    return LieAlg{};
+  }
+};
+
+//! @brief Random specialization for DHuTangentBase objects.
+template <typename Derived>
+struct RandomEvaluatorImpl<DHuTangentBase<Derived>>
+{
+  static void run(DHuTangentBase<Derived>& m)
+  {
+    // @todo check
+    m.coeffs().setRandom(); // in [-1,1]
+    m.coeffs() *= MANIF_PI; // in [-PI,PI]
+  }
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_DHUTANGENT_BASE_H_

--- a/include/manif/impl/dhu/DHuTangent_map.h
+++ b/include/manif/impl/dhu/DHuTangent_map.h
@@ -1,0 +1,89 @@
+#ifndef _MANIF_MANIF_DHUTANGENT_MAP_H_
+#define _MANIF_MANIF_DHUTANGENT_MAP_H_
+
+#include "manif/impl/dhu/DHuTangent.h"
+
+namespace manif {
+namespace internal {
+
+//! @brief traits specialization for Eigen Map
+template <typename _Scalar>
+struct traits< Eigen::Map<DHuTangent<_Scalar>,0> >
+    : public traits<DHuTangent<_Scalar>>
+{
+  using typename traits<DHuTangent<_Scalar>>::Scalar;
+  using traits<DHuTangent<_Scalar>>::DoF;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, DoF, 1>, 0>;
+  using Base = DHuTangentBase<Eigen::Map<DHuTangent<Scalar>, 0>>;
+};
+
+//! @brief traits specialization for Eigen Map
+template <typename _Scalar>
+struct traits< Eigen::Map<const DHuTangent<_Scalar>,0> >
+    : public traits<const DHuTangent<_Scalar>>
+{
+  using typename traits<const DHuTangent<_Scalar>>::Scalar;
+  using traits<const DHuTangent<_Scalar>>::DoF;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, DoF, 1>, 0>;
+  using Base = DHuTangentBase<Eigen::Map<const DHuTangent<Scalar>, 0>>;
+};
+
+} // namespace internal
+} // namespace manif
+
+namespace Eigen {
+
+/**
+ * @brief Specialization of Map for manif::DHu
+ */
+template <class _Scalar>
+class Map<manif::DHuTangent<_Scalar>, 0>
+    : public manif::DHuTangentBase<Map<manif::DHuTangent<_Scalar>, 0> >
+{
+  using Base = manif::DHuTangentBase<Map<manif::DHuTangent<_Scalar>, 0> >;
+
+public:
+
+  MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
+  MANIF_INHERIT_TANGENT_OPERATOR
+
+  Map(Scalar* coeffs) : data_(coeffs) { }
+
+  MANIF_TANGENT_MAP_ASSIGN_OP(DHuTangent)
+
+  DataType& coeffs() { return data_; }
+  const DataType& coeffs() const { return data_; }
+
+protected:
+
+  DataType data_;
+};
+
+/**
+ * @brief Specialization of Map for const manif::DHu
+ */
+template <class _Scalar>
+class Map<const manif::DHuTangent<_Scalar>, 0>
+    : public manif::DHuTangentBase<Map<const manif::DHuTangent<_Scalar>, 0> >
+{
+  using Base = manif::DHuTangentBase<Map<const manif::DHuTangent<_Scalar>, 0> >;
+
+public:
+
+  MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
+  MANIF_INHERIT_TANGENT_OPERATOR
+
+  Map(const Scalar* coeffs) : data_(coeffs) { }
+
+  const DataType& coeffs() const { return data_; }
+
+protected:
+
+  const DataType data_;
+};
+
+} // namespace Eigen
+
+#endif // _MANIF_MANIF_DHUTANGENT_MAP_H_

--- a/include/manif/impl/dhu/DHu_base.h
+++ b/include/manif/impl/dhu/DHu_base.h
@@ -1,0 +1,411 @@
+#ifndef _MANIF_MANIF_DHU_BASE_H_
+#define _MANIF_MANIF_DHU_BASE_H_
+
+#include "manif/impl/dhu/DHu_properties.h"
+#include "manif/impl/lie_group_base.h"
+
+namespace manif {
+
+//
+// LieGroup
+//
+
+/**
+ * @brief The base class of the DHu group (Unit Dual Quaternion).
+ * @note s = [r,d] = [r0,r1,r2,r3, d0,d1,d2,d3]
+ * with r (real) is a quaternion q = [x,y,z,w] and
+ * with d (dual) is a quaternion q = [x,y,z,w].
+ * A dual quaternion is unit if s . s* = 1, that is if
+ * |r| = 1
+ * and
+ * r dot d = 0
+ */
+template <typename _Derived>
+struct DHuBase : LieGroupBase<_Derived>
+{
+private:
+
+  using Base = LieGroupBase<_Derived>;
+  using Type = DHuBase<_Derived>;
+
+public:
+
+  MANIF_GROUP_TYPEDEF
+  MANIF_INHERIT_GROUP_AUTO_API
+  MANIF_INHERIT_GROUP_OPERATOR
+
+  using Base::coeffs;
+
+  using Rotation       = typename internal::traits<_Derived>::Rotation;
+  using Translation    = typename internal::traits<_Derived>::Translation;
+  using Transformation = typename internal::traits<_Derived>::Transformation;
+  using Isometry       = Eigen::Transform<Scalar, 3, Eigen::Isometry>;
+  using Quaternion     = Eigen::Quaternion<Scalar>;
+  using Real           = Quaternion;
+  using Dual           = Quaternion;
+
+  // LieGroup common API
+
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(DHuBase)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(DHuBase)
+
+  /**
+   * @brief Get the inverse.
+   * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
+   */
+  LieGroup inverse(OptJacobianRef J_minv_m = {}) const;
+
+  /**
+   * @brief Get the DHu corresponding Lie algebra element in vector form.
+   * @param[out] -optional- J_t_m Jacobian of the tangent wrt to this.
+   * @return The DHu tangent of this.
+   * @note This is the log() map in vector form.
+   * @see DHuTangent.
+   */
+  Tangent log(OptJacobianRef J_t_m = {}) const;
+
+  /**
+   * @brief This function is deprecated.
+   * Please considere using
+   * @ref log instead.
+   */
+  MANIF_DEPRECATED
+  Tangent lift(OptJacobianRef J_t_m = {}) const;
+
+  /**
+   * @brief Composition of this and another DHu element.
+   * @param[in] m Another DHu element.
+   * @param[out] -optional- J_mc_ma Jacobian of the composition wrt this.
+   * @param[out] -optional- J_mc_mb Jacobian of the composition wrt m.
+   * @return The composition of 'this . m'.
+   */
+  template <typename _DerivedOther>
+  LieGroup compose(const LieGroupBase<_DerivedOther>& m,
+                   OptJacobianRef J_mc_ma = {},
+                   OptJacobianRef J_mc_mb = {}) const;
+
+  /**
+   * @brief Rigid motion action on a 3D point.
+   * @param  v A 3D point.
+   * @param[out] -optional- J_vout_m The Jacobian of the new object wrt this.
+   * @param[out] -optional- J_vout_v The Jacobian of the new object wrt input object.
+   * @return The transformed 3D point.
+   */
+  template <typename _EigenDerived>
+  Eigen::Matrix<Scalar, 3, 1>
+  act(const Eigen::MatrixBase<_EigenDerived> &v,
+      tl::optional<Eigen::Ref<Eigen::Matrix<Scalar, 3, 6>>> J_vout_m = {},
+      tl::optional<Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>>> J_vout_v = {}) const;
+
+  /**
+   * @brief Get the adjoint matrix of DHu at this.
+   */
+  Jacobian adj() const;
+
+  // DHu specific functions
+
+  LieGroup conjugate() const;
+  LieGroup conjugatedual() const;
+
+  /**
+   * Get the transformation matrix (3D isometry).
+   * @note T = | R t |
+   *           | 0 1 |
+   */
+  Transformation transform() const;
+
+  /**
+   * Get the isometry object (Eigen 3D isometry).
+   * @note T = | R t |
+   *           | 0 1 |
+   */
+  Isometry isometry() const;
+
+  /**
+   * @brief Get the rotational part of this as a rotation matrix.
+   */
+  Rotation rotation() const;
+
+  /**
+   * @brief Get the real part of this as a quaternion.
+   */
+  Real real() const;
+
+  /**
+   * @brief Get the dual part of this as a quaternion.
+   */
+  Dual dual() const;
+
+  /**
+   * @brief Get the translational part in vector form.
+   */
+  Translation translation() const;
+
+  /**
+   * @brief Normalize the underlying dual quaternion.
+   */
+  void normalize();
+};
+
+template <typename _Derived>
+typename DHuBase<_Derived>::LieGroup
+DHuBase<_Derived>::inverse(OptJacobianRef J_minv_m) const
+{
+  if (J_minv_m)
+  {
+    (*J_minv_m) = -adj();
+  }
+
+  return conjugate();
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Tangent
+DHuBase<_Derived>::log(OptJacobianRef J_t_m) const
+{
+  // @todo
+  Tangent tan;
+
+  if (J_t_m)
+  {
+    // Jr^-1
+    (*J_t_m) = tan.rjacinv();
+  }
+
+  return tan;
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Tangent
+DHuBase<_Derived>::lift(OptJacobianRef J_t_m) const
+{
+  return log(J_t_m);
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+typename DHuBase<_Derived>::LieGroup
+DHuBase<_Derived>::compose(
+    const LieGroupBase<_DerivedOther>& m,
+    OptJacobianRef J_mc_ma,
+    OptJacobianRef J_mc_mb) const
+{
+  static_assert(
+    std::is_base_of<DHuBase<_DerivedOther>, _DerivedOther>::value,
+    "Argument does not inherit from DHuBase !");
+  
+  const auto& m_DHu = static_cast<const DHuBase<_DerivedOther>&>(m);
+
+  if (J_mc_ma)
+  {
+    (*J_mc_ma) = m_DHu.inverse().adj();
+  }
+
+  if (J_mc_mb)
+  {
+    J_mc_mb->setIdentity();
+  }
+
+  return LieGroup(real()*m_DHu.real(),
+                  Quaternion((real()*m_DHu.dual()).coeffs()+(dual()*m_DHu.real()).coeffs()));
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+Eigen::Matrix<typename DHuBase<_Derived>::Scalar, 3, 1>
+DHuBase<_Derived>::act(const Eigen::MatrixBase<_EigenDerived> &v,
+                       tl::optional<Eigen::Ref<Eigen::Matrix<Scalar, 3, 6>>> J_vout_m,
+                       tl::optional<Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>>> J_vout_v) const
+{
+  assert_vector_dim(v, 3);
+  const Rotation R(rotation());
+
+  if (J_vout_m)
+  {
+    // @todo
+  }
+
+  if (J_vout_v)
+  {
+    // @todo
+  }
+
+  // @todo do it in a dual quat fashion
+  return translation() + R * v;
+}
+
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Jacobian
+DHuBase<_Derived>::adj() const
+{
+  // @todo
+
+  return Jacobian();
+}
+
+// DHu specific function
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Transformation
+DHuBase<_Derived>::transform() const
+{
+  Transformation T = Transformation::Identity();
+  T.template topLeftCorner<3,3>()  = rotation();
+  T.template topRightCorner<3,1>() = translation();
+  return T;
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Isometry
+DHuBase<_Derived>::isometry() const
+{
+  return Isometry(transform());
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Rotation
+DHuBase<_Derived>::rotation() const
+{
+  return real().matrix();
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Real
+DHuBase<_Derived>::real() const
+{
+  return Real(coeffs().template head<4>());
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Dual
+DHuBase<_Derived>::dual() const
+{
+  return Real(coeffs().template tail<4>());
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::Translation
+DHuBase<_Derived>::translation() const
+{
+  return dual()*real().conjugate()*Scalar(2);
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::LieGroup
+DHuBase<_Derived>::conjugate() const
+{
+  return LieGroup(real().conjugate(), dual().conjugate());
+}
+
+template <typename _Derived>
+typename DHuBase<_Derived>::LieGroup
+DHuBase<_Derived>::conjugatedual() const
+{
+  return LieGroup((DataType() << coeffs().template head<4>(), 
+                                -coeffs().template tail<4>()).finished());
+}
+
+template <typename _Derived>
+void DHuBase<_Derived>::normalize()
+{
+  const Scalar n = coeffs().template head<4>().norm();
+  coeffs() /= n;
+  // real and dual parts are orthogonal
+  coeffs().template tail<4>() -= (coeffs().template head<4>().dot(coeffs().template tail<4>())) * coeffs().template head<4>();
+}
+
+namespace internal {
+
+//! @brief Random specialization for DHuBase objects.
+template <typename Derived>
+struct RandomEvaluatorImpl<DHuBase<Derived>>
+{
+  template <typename T>
+  static void run(T& m)
+  {
+    // @note:
+    // Quaternion::UnitRandom is not available in Eigen 3.3-beta1
+    // which is the default version in Ubuntu 16.04
+    // So we copy its implementation here.
+
+    using std::sqrt;
+    using std::sin;
+    using std::cos;
+
+    using Scalar      = typename DHuBase<Derived>::Scalar;
+    using LieGroup    = typename DHuBase<Derived>::LieGroup;
+    using DataType    = typename DHuBase<Derived>::DataType;
+
+    Scalar u1 = Eigen::internal::random<Scalar>(0, 1),
+           u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI),
+           u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
+    Scalar a = sqrt(Scalar(1) - u1),
+           b = sqrt(u1);
+
+    Eigen::Matrix<Scalar, 4, 1> real(a * cos(u2),b * sin(u3),b * cos(u3),a * sin(u2));
+
+    u1 = Eigen::internal::random<Scalar>(0, 1);
+    u2 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
+    u3 = Eigen::internal::random<Scalar>(0, 2*EIGEN_PI);
+    a = sqrt(Scalar(1) - u1);
+    b = sqrt(u1);
+
+    Eigen::Matrix<Scalar, 4, 1> dual(a * cos(u2),b * sin(u3),b * cos(u3),a * sin(u2));
+
+    dual -= real.dot(dual) * real;
+
+    m = LieGroup((DataType() << real, dual).finished());
+    
+    // @note see https://scicomp.stackexchange.com/a/27843
+
+    // Scalar x = a * cos(u2),
+    //        y = b * sin(u3),
+    //        z = b * cos(u3),
+    //        w = a * sin(u2);
+
+    // Eigen::Matrix<Scalar, 4, 3> M;
+    // M << -x, -y, -z,
+    //       w,  z, -y,
+    //      -z,  w,  x,
+    //       y, -x,  w;
+
+    // const Eigen::Matrix<Scalar, 4, 1> v = M * Eigen::Matrix<Scalar, 3, 1>::Random().normalized();
+
+    // m = LieGroup((DataType() << x, y, z, w, v(1), v(2), v(3), v(0)).finished());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<DHuBase<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename DHuBase<Derived>::Scalar;
+    // |r| = 1
+    MANIF_CHECK(abs(data.template head<4>().norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "DHu real part not normalized !",
+                invalid_argument);
+    // r dot d = 0
+    MANIF_CHECK(abs(data.template head<4>().dot(data.template tail<4>())) <
+                Constants<Scalar>::eps_s,
+                "DHu dual part not normalized !",
+                invalid_argument);
+  }
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_DHU_BASE_H_

--- a/include/manif/impl/dhu/DHu_map.h
+++ b/include/manif/impl/dhu/DHu_map.h
@@ -1,0 +1,91 @@
+#ifndef _MANIF_MANIF_DHU_MAP_H_
+#define _MANIF_MANIF_DHU_MAP_H_
+
+#include "manif/impl/dhu/DHu.h"
+
+namespace manif {
+namespace internal {
+
+//! @brief traits specialization for Eigen Map
+template <typename _Scalar>
+struct traits< Eigen::Map<DHu<_Scalar>,0> >
+    : public traits<DHu<_Scalar>>
+{
+  using typename traits<DHu<_Scalar>>::Scalar;
+  using traits<DHu<Scalar>>::RepSize;
+  using Base = DHuBase<Eigen::Map<DHu<Scalar>, 0>>;
+  using DataType = Eigen::Map<Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+};
+
+//! @brief traits specialization for Eigen Map const
+template <typename _Scalar>
+struct traits< Eigen::Map<const DHu<_Scalar>,0> >
+    : public traits<const DHu<_Scalar>>
+{
+  using typename traits<const DHu<_Scalar>>::Scalar;
+  using traits<const DHu<Scalar>>::RepSize;
+  using Base = DHuBase<Eigen::Map<const DHu<Scalar>, 0>>;
+  using DataType = Eigen::Map<const Eigen::Matrix<Scalar, RepSize, 1>, 0>;
+};
+
+} // namespace internal
+} // namespace manif
+
+namespace Eigen {
+
+/**
+ * @brief Specialization of Map for manif::DHu
+ */
+template <class _Scalar>
+class Map<manif::DHu<_Scalar>, 0>
+    : public manif::DHuBase<Map<manif::DHu<_Scalar>, 0> >
+{
+  using Base = manif::DHuBase<Map<manif::DHu<_Scalar>, 0> >;
+
+public:
+
+  MANIF_COMPLETE_GROUP_TYPEDEF
+  MANIF_INHERIT_GROUP_API
+  using Base::transform;
+  using Base::rotation;
+
+  Map(Scalar* coeffs) : data_(coeffs) { }
+
+  MANIF_GROUP_MAP_ASSIGN_OP(DHu)
+
+  DataType& coeffs() { return data_; }
+  const DataType& coeffs() const { return data_; }
+
+protected:
+
+  DataType data_;
+};
+
+/**
+ * @brief Specialization of Map for const manif::DHu
+ */
+template <class _Scalar>
+class Map<const manif::DHu<_Scalar>, 0>
+    : public manif::DHuBase<Map<const manif::DHu<_Scalar>, 0> >
+{
+  using Base = manif::DHuBase<Map<const manif::DHu<_Scalar>, 0> >;
+
+public:
+
+  MANIF_COMPLETE_GROUP_TYPEDEF
+  MANIF_INHERIT_GROUP_API
+  using Base::transform;
+  using Base::rotation;
+
+  Map(const Scalar* coeffs) : data_(coeffs) { }
+
+  const DataType& coeffs() const { return data_; }
+
+protected:
+
+  const DataType data_;
+};
+
+} // namespace Eigen
+
+#endif // _MANIF_MANIF_DHU_MAP_H_

--- a/include/manif/impl/dhu/DHu_properties.h
+++ b/include/manif/impl/dhu/DHu_properties.h
@@ -1,0 +1,33 @@
+#ifndef _MANIF_MANIF_DHU_PROPERTIES_H_
+#define _MANIF_MANIF_DHU_PROPERTIES_H_
+
+#include "manif/impl/traits.h"
+
+namespace manif {
+
+// Forward declaration
+template <typename _Derived> struct DHuBase;
+template <typename _Derived> struct DHuTangentBase;
+
+namespace internal {
+
+//! traits specialization
+template <typename _Derived>
+struct LieGroupProperties<DHuBase<_Derived>>
+{
+  static constexpr int Dim = 3; /// @brief Space dimension
+  static constexpr int DoF = 6; /// @brief Degrees of freedom
+};
+
+//! traits specialization
+template <typename _Derived>
+struct LieGroupProperties<DHuTangentBase<_Derived>>
+{
+  static constexpr int Dim = 3; /// @brief Space dimension
+  static constexpr int DoF = 6; /// @brief Degrees of freedom
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_DHU_PROPERTIES_H_

--- a/include/manif/impl/eigen.h
+++ b/include/manif/impl/eigen.h
@@ -2,6 +2,8 @@
 #define _MANIF_MANIF_EIGEN_H_
 
 #include <Eigen/Core>
+#include <Eigen/LU> // for mat.inverse()
+#include <Eigen/Geometry>
 
 /**
  * @note static_cast<int> to avoid -Wno-enum-compare

--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -5,6 +5,7 @@
 #include "manif/impl/traits.h"
 #include "manif/impl/eigen.h"
 #include "manif/impl/tangent_base.h"
+#include "manif/impl/assignment_assert.h"
 
 #include "manif/constants.h"
 
@@ -40,6 +41,37 @@ public:
 
   //! @brief Helper for skipping an optional parameter.
   static const OptJacobianRef _;
+
+protected:
+
+  MANIF_DEFAULT_CONSTRUCTOR(LieGroupBase)
+
+public:
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   * @note This is a special case of the templated operator=. Its purpose is to
+   * prevent a default operator= from hiding the templated operator=.
+   */
+  _Derived& operator =(const LieGroupBase& m);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   */
+  template <typename _DerivedOther>
+  _Derived& operator =(const LieGroupBase<_DerivedOther>& m);
+
+  /**
+   * @brief Assignment operator given Eigen object.
+   * @param[in] An element of the Lie group.
+   * @return A reference to this.
+   */
+  template <typename _EigenDerived>
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& data);
 
   //! @brief Access the underlying data by const reference
   DataType& coeffs();
@@ -235,21 +267,6 @@ public:
   // Some operators
 
   /**
-   * @brief Assignment operator.
-   * @param[in] An element of the Lie group.
-   * @return A reference to this.
-   */
-  _Derived& operator =(const LieGroupBase<_Derived>& m);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] An element of the Lie group.
-   * @return A reference to this.
-   */
-  template <typename _DerivedOther>
-  _Derived& operator =(const LieGroupBase<_DerivedOther>& m);
-
-  /**
    * @brief Equality operator.
    * @param[in] An element of the same Lie group.
    * @return true if the Lie group element m is 'close' to this,
@@ -301,10 +318,10 @@ public:
   //! Static helper to create a random object of the Lie group.
   static LieGroup Random();
 
-private:
+protected:
 
-  _Derived& derived() { return *static_cast< _Derived* >(this); }
-  const _Derived& derived() const { return *static_cast< const _Derived* >(this); }
+  inline _Derived& derived() & noexcept { return *static_cast< _Derived* >(this); }
+  inline const _Derived& derived() const & noexcept { return *static_cast< const _Derived* >(this); }
 };
 
 template <typename _Derived>
@@ -317,6 +334,37 @@ constexpr int LieGroupBase<_Derived>::RepSize;
 template <typename _Derived>
 const typename LieGroupBase<_Derived>::OptJacobianRef
 LieGroupBase<_Derived>::_ = {};
+
+// Copy
+
+template <typename _Derived>
+_Derived&
+LieGroupBase<_Derived>::operator =(const LieGroupBase& m)
+{
+  derived().coeffs() = m.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+_Derived&
+LieGroupBase<_Derived>::operator =(const LieGroupBase<_DerivedOther>& m)
+{
+  derived().coeffs() = m.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+_Derived&
+LieGroupBase<_Derived>::operator =(const Eigen::MatrixBase<_EigenDerived>& data)
+{
+  internal::AssignmentEvaluator<
+      typename internal::traits<_Derived>::Base>().run(data);
+
+  derived().coeffs() = data;
+  return derived();
+}
 
 template <typename _Derived>
 typename LieGroupBase<_Derived>::DataType&
@@ -562,25 +610,6 @@ LieGroupBase<_Derived>::act(const Vector& v,
 }
 
 // Operators
-
-template <typename _Derived>
-_Derived&
-LieGroupBase<_Derived>::operator =(
-    const LieGroupBase<_Derived>& m)
-{
-  derived().coeffs() = m.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _DerivedOther>
-_Derived&
-LieGroupBase<_Derived>::operator =(
-    const LieGroupBase<_DerivedOther>& m)
-{
-  derived().coeffs() = m.coeffs();
-  return derived();
-}
 
 template <typename _Derived>
 template <typename _DerivedOther>

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -116,6 +116,78 @@ raise(Args&&... args)
 #define MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND_TYPE(X) \
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF((Eigen::internal::traits<typename X::DataType>::Alignment>0))
 
+#define MANIF_DEFAULT_CONSTRUCTOR(X)  \
+  X() = default;                      \
+  ~X() = default;                     \
+  X(const X&) = default;              \
+  X(X&&) = delete;
+
+#define MANIF_GROUP_ML_ASSIGN_OP(X) \
+  _Derived& operator =(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_GROUP_ASSIGN_OP(X) \
+  X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_GROUP_MAP_ASSIGN_OP(X) \
+  Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::LieGroupBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+
+#define MANIF_TANGENT_ML_ASSIGN_OP(X) \
+  _Derived& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  _Derived& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_TANGENT_ASSIGN_OP(X) \
+  X& operator=(const X& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _DerivedOther>\
+  X& operator =(const TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return derived(); }\
+  template <typename _EigenDerived>\
+  X& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return derived(); }
+
+#define MANIF_TANGENT_MAP_ASSIGN_OP(X) \
+  Map& operator=(const Map& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::X##Base<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _DerivedOther>\
+  Map& operator =(const manif::TangentBase<_DerivedOther>& o) { coeffs() = o.coeffs(); return *this; }\
+  template <typename _EigenDerived>\
+  Map& operator =(const Eigen::MatrixBase<_EigenDerived>& o) { coeffs() = o; return *this; }
+
+/**
+ * @brief Automatically define:
+ * - copy constructor
+ * - copy constructor given Base object
+ * - copy constructor given Eigen object
+ */
+#define MANIF_COPY_CONSTRUCTOR(X)                                                           \
+  X(const X& o) : Base(), data_(o.coeffs()) { }                                             \
+  X(const Base& o) : Base(), data_(o.coeffs()) { }                                          \
+  template <typename D> X(const Eigen::MatrixBase<D>& o) : Base(), data_(o)                 \
+    { manif::internal::AssignmentEvaluator<Base>().run(o); }
+
+#define MANIF_COEFFS_FUNCTIONS()                      \
+  DataType& coeffs() & { return data_; }              \
+  const DataType& coeffs() const & { return data_; }
+
 // LieGroup - related macros
 
 #define MANIF_INHERIT_GROUP_AUTO_API    \

--- a/include/manif/impl/rn/Rn.h
+++ b/include/manif/impl/rn/Rn.h
@@ -56,6 +56,10 @@ private:
   using Base = RnBase<Rn<_Scalar, _N>>;
   using Type = Rn<_Scalar, _N>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -66,22 +70,17 @@ public:
   Rn()  = default;
   ~Rn() = default;
 
+  MANIF_COPY_CONSTRUCTOR(Rn)
+
   // Copy constructor given base
-  Rn(const Base& o);
-
-  template <typename _DerivedOther>
-  Rn(const RnBase<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   Rn(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  Rn(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(Rn)
 
   // LieGroup common API
 
-  //! Get a const reference to the underlying DataType.
+  //! Get a reference to the underlying DataType.
   DataType& coeffs();
 
   //! Get a const reference to the underlying DataType.
@@ -113,29 +112,6 @@ MANIF_EXTRA_GROUP_TYPEDEF(R6)
 MANIF_EXTRA_GROUP_TYPEDEF(R7)
 MANIF_EXTRA_GROUP_TYPEDEF(R8)
 MANIF_EXTRA_GROUP_TYPEDEF(R9)
-
-template <typename _Scalar, unsigned int _N>
-template <typename _EigenDerived>
-Rn<_Scalar, _N>::Rn(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-Rn<_Scalar, _N>::Rn(const Base& o)
-  : Rn(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _DerivedOther>
-Rn<_Scalar, _N>::Rn(const RnBase<_DerivedOther>& o)
-  : Rn(o.coeffs())
-{
-  //
-}
 
 template <typename _Scalar, unsigned int _N>
 template <typename _DerivedOther>

--- a/include/manif/impl/rn/RnTangent.h
+++ b/include/manif/impl/rn/RnTangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/rn/RnTangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/rn/RnTangent.h
+++ b/include/manif/impl/rn/RnTangent.h
@@ -51,6 +51,10 @@ private:
   using Base = RnTangentBase<RnTangent<_Scalar, _N>>;
   using Type = RnTangent<_Scalar, _N>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -62,17 +66,13 @@ public:
   RnTangent()  = default;
   ~RnTangent() = default;
 
-  // Copy constructor given base
-  RnTangent(const Base& o);
-  template <typename _DerivedOther>
-  RnTangent(const RnTangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(RnTangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   RnTangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  RnTangent(const Eigen::MatrixBase<_EigenDerived>& theta);
+  MANIF_TANGENT_ASSIGN_OP(RnTangent)
 
   // Tangent common API
 
@@ -105,35 +105,9 @@ MANIF_EXTRA_GROUP_TYPEDEF(R8Tangent)
 MANIF_EXTRA_GROUP_TYPEDEF(R9Tangent)
 
 template <typename _Scalar, unsigned int _N>
-RnTangent<_Scalar, _N>::RnTangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
 template <typename _DerivedOther>
-RnTangent<_Scalar, _N>::RnTangent(
-    const RnTangentBase<_DerivedOther>& o)
+RnTangent<_Scalar, _N>::RnTangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _DerivedOther>
-RnTangent<_Scalar, _N>::RnTangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar, unsigned int _N>
-template <typename _EigenDerived>
-RnTangent<_Scalar, _N>::RnTangent(
-    const Eigen::MatrixBase<_EigenDerived>& theta)
-  : data_(theta)
 {
   //
 }

--- a/include/manif/impl/rn/RnTangent_base.h
+++ b/include/manif/impl/rn/RnTangent_base.h
@@ -28,8 +28,15 @@ public:
   MANIF_INHERIT_TANGENT_OPERATOR
   using Base::coeffs;
 
-  RnTangentBase()  = default;
-  ~RnTangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(RnTangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(RnTangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/rn/RnTangent_map.h
+++ b/include/manif/impl/rn/RnTangent_map.h
@@ -48,6 +48,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(RnTangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/rn/Rn_base.h
+++ b/include/manif/impl/rn/Rn_base.h
@@ -35,6 +35,15 @@ public:
   using Transformation = typename internal::traits<_Derived>::Transformation;
 
   // LieGroup common API
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(RnBase)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(RnBase)
 
   /**
    * @brief Get the inverse of this.
@@ -103,14 +112,6 @@ public:
    *           | 0 1 |
    */
   Transformation transform() const;
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] v An Eigen MatrixBase (vector expected).
-   * @return A reference to this.
-   */
-  template<typename _EigenDerived>
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
 };
 
 template <typename _Derived>
@@ -120,15 +121,6 @@ RnBase<_Derived>::transform() const
   Transformation T(Transformation::Identity());
   T.template topRightCorner<Dim,1>() = coeffs();
   return T;
-}
-
-template <typename _Derived>
-template <typename _EigenDerived>
-_Derived& RnBase<_Derived>::operator =(
-  const Eigen::MatrixBase<_EigenDerived>& v)
-{
-  coeffs() = v;
-  return *static_cast< _Derived* >(this);
 }
 
 template <typename _Derived>

--- a/include/manif/impl/rn/Rn_map.h
+++ b/include/manif/impl/rn/Rn_map.h
@@ -49,8 +49,9 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
-  DataType& coeffs() { return data_; }
+  MANIF_GROUP_MAP_ASSIGN_OP(Rn)
 
+  DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 
 protected:

--- a/include/manif/impl/se2/SE2.h
+++ b/include/manif/impl/se2/SE2.h
@@ -56,6 +56,10 @@ private:
   using Base = SE2Base<SE2<_Scalar>>;
   using Type = SE2<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -70,18 +74,13 @@ public:
   SE2()  = default;
   ~SE2() = default;
 
-  // Copy constructor given base
-  SE2(const Base& o);
+  MANIF_COPY_CONSTRUCTOR(SE2)
 
-  template <typename _DerivedOther>
-  SE2(const SE2Base<_DerivedOther>& o);
-
+  // Copy constructor
   template <typename _DerivedOther>
   SE2(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE2(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SE2)
 
   /**
    * @brief Constructor given a translation and a unit complex number.
@@ -133,7 +132,16 @@ public:
 
   // LieGroup common API
 
+  /**
+   * @brief Access the underlying data
+   * @param[out] a reference to the underlying Eigen vector
+   */
   DataType& coeffs();
+
+  /**
+   * @brief Access the underlying data
+   * @param[out] a const reference to the underlying Eigen vector
+   */
   const DataType& coeffs() const;
 
   // SE2 specific API
@@ -146,43 +154,15 @@ public:
 
 protected:
 
+  //! Underlying data (Eigen) vector
   DataType data_;
 };
 
 MANIF_EXTRA_GROUP_TYPEDEF(SE2)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SE2<_Scalar>::SE2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.template tail<2>().norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "SE2 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SE2<_Scalar>::SE2(const Base& o)
-  : SE2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE2<_Scalar>::SE2(
-    const SE2Base<_DerivedOther>& o)
-  : SE2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE2<_Scalar>::SE2(
-    const LieGroupBase<_DerivedOther>& o)
+SE2<_Scalar>::SE2(const LieGroupBase<_DerivedOther>& o)
   : SE2(o.coeffs())
 {
   //
@@ -220,7 +200,7 @@ SE2<_Scalar>::SE2(const Scalar x, const Scalar y, const std::complex<Scalar>& c)
 }
 
 template <typename _Scalar>
-SE2<_Scalar>::SE2(const Eigen::Transform<_Scalar,2,Eigen::Isometry>& h)
+SE2<_Scalar>::SE2(const Eigen::Transform<_Scalar, 2, Eigen::Isometry>& h)
   : SE2(h.translation().x(), h.translation().y(), Eigen::Rotation2D<Scalar>(h.rotation()).angle())
 {
   //

--- a/include/manif/impl/se2/SE2Tangent.h
+++ b/include/manif/impl/se2/SE2Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SE2TangentBase<SE2Tangent<_Scalar>>;
   using Type = SE2Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SE2Tangent()  = default;
   ~SE2Tangent() = default;
 
-  // Copy constructor given base
-  SE2Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SE2Tangent(const SE2TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE2Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SE2Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE2Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SE2Tangent)
 
   SE2Tangent(const Scalar x, const Scalar y, const Scalar theta);
 
@@ -91,35 +91,9 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SE2Tangent);
 
 template <typename _Scalar>
-SE2Tangent<_Scalar>::SE2Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const SE2TangentBase<_DerivedOther>& o)
+SE2Tangent<_Scalar>::SE2Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE2Tangent<_Scalar>::SE2Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/se2/SE2Tangent.h
+++ b/include/manif/impl/se2/SE2Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se2/SE2Tangent_base.h"
 
-#include <Eigen/Dense>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -24,14 +24,22 @@ private:
 
 public:
 
-  SE2TangentBase()  = default;
-  ~SE2TangentBase() = default;
-
   MANIF_TANGENT_TYPEDEF
+  MANIF_INHERIT_TANGENT_API
   MANIF_INHERIT_TANGENT_OPERATOR
 
   using Base::data;
   using Base::coeffs;
+
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE2TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SE2TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/se2/SE2Tangent_map.h
+++ b/include/manif/impl/se2/SE2Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SE2Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -38,6 +38,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE2Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SE2Base)
+
   /**
    * @brief Get the inverse of this.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -393,6 +403,22 @@ struct RandomEvaluatorImpl<SE2Base<Derived>>
   {
     using Tangent = typename LieGroupBase<Derived>::Tangent;
     m = Tangent::Random().exp();
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SE2Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SE2Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.template tail<2>().norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "SE2 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/se2/SE2_map.h
+++ b/include/manif/impl/se2/SE2_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SE2)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -59,6 +59,10 @@ private:
   using Base = SE3Base<SE3<_Scalar>>;
   using Type = SE3<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -75,18 +79,12 @@ public:
   SE3()  = default;
   ~SE3() = default;
 
-  // Copy constructor given base
-  SE3(const Base& o);
-
-  template <typename _DerivedOther>
-  SE3(const SE3Base<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE3)
 
   template <typename _DerivedOther>
   SE3(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE3(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SE3)
 
   /**
    * @brief Constructor given a translation and a unit quaternion.
@@ -150,53 +148,22 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SE3)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SE3<_Scalar>::SE3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.template tail<4>().norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "SE3 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SE3<_Scalar>::SE3(const Base& o)
-  : SE3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SE3<_Scalar>::SE3(
-    const SE3Base<_DerivedOther>& o)
+SE3<_Scalar>::SE3(const LieGroupBase<_DerivedOther>& o)
   : SE3(o.coeffs())
 {
   //
 }
 
 template <typename _Scalar>
-template <typename _DerivedOther>
-SE3<_Scalar>::SE3(
-    const LieGroupBase<_DerivedOther>& o)
-  : SE3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const Eigen::Quaternion<Scalar>& q)
+SE3<_Scalar>::SE3(const Translation& t, const Eigen::Quaternion<Scalar>& q)
   : SE3((DataType() << t, q.coeffs() ).finished())
 {
   //
 }
 
 template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const Eigen::AngleAxis<Scalar>& a)
+SE3<_Scalar>::SE3(const Translation& t, const Eigen::AngleAxis<Scalar>& a)
   : SE3(t, Quaternion(a))
 {
   //
@@ -206,16 +173,15 @@ template <typename _Scalar>
 SE3<_Scalar>::SE3(const Scalar x, const Scalar y, const Scalar z,
                   const Scalar roll, const Scalar pitch, const Scalar yaw)
   : SE3(Translation(x,y,z), Eigen::Quaternion<Scalar>(
-          Eigen::AngleAxis<Scalar>(yaw,   Eigen::Matrix<Scalar, 3, 1>::UnitZ()) *
-          Eigen::AngleAxis<Scalar>(pitch, Eigen::Matrix<Scalar, 3, 1>::UnitY()) *
-          Eigen::AngleAxis<Scalar>(roll,  Eigen::Matrix<Scalar, 3, 1>::UnitX())  ))
+      Eigen::AngleAxis<Scalar>(yaw,   Eigen::Matrix<Scalar, 3, 1>::UnitZ()) *
+      Eigen::AngleAxis<Scalar>(pitch, Eigen::Matrix<Scalar, 3, 1>::UnitY()) *
+      Eigen::AngleAxis<Scalar>(roll,  Eigen::Matrix<Scalar, 3, 1>::UnitX())  ))
 {
   //
 }
 
 template <typename _Scalar>
-SE3<_Scalar>::SE3(const Translation& t,
-                  const SO3<Scalar>& so3)
+SE3<_Scalar>::SE3(const Translation& t, const SO3<Scalar>& so3)
   : SE3(t, so3.quat())
 {
   //
@@ -227,7 +193,6 @@ SE3<_Scalar>::SE3(const Eigen::Transform<_Scalar,3,Eigen::Isometry>& h)
 {
   //
 }
-
 
 template <typename _Scalar>
 typename SE3<_Scalar>::DataType&

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se3/SE3_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 
 // Forward declare for type traits specialization

--- a/include/manif/impl/se3/SE3Tangent.h
+++ b/include/manif/impl/se3/SE3Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SE3TangentBase<SE3Tangent<_Scalar>>;
   using Type = SE3Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SE3Tangent()  = default;
   ~SE3Tangent() = default;
 
-  // Copy constructor given base
-  SE3Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SE3Tangent(const SE3TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SE3Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SE3Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SE3Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SE3Tangent)
 
   // Tangent common API
 
@@ -87,35 +87,10 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SE3Tangent);
 
 template <typename _Scalar>
-SE3Tangent<_Scalar>::SE3Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SE3Tangent<_Scalar>::SE3Tangent(
-    const SE3TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
 SE3Tangent<_Scalar>::SE3Tangent(
     const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SE3Tangent<_Scalar>::SE3Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/se3/SE3Tangent.h
+++ b/include/manif/impl/se3/SE3Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/se3/SE3Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -36,8 +36,15 @@ public:
   using Base::data;
   using Base::coeffs;
 
-  SE3TangentBase()  = default;
-  ~SE3TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE3TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SE3TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/se3/SE3Tangent_map.h
+++ b/include/manif/impl/se3/SE3Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SE3Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -5,8 +5,6 @@
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/so3/SO3_map.h"
 
-#include <Eigen/Geometry>
-
 namespace manif {
 
 //

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -42,6 +42,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SE3Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SE3Base)
+
   /**
    * @brief Get the inverse.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -393,6 +403,22 @@ struct RandomEvaluatorImpl<SE3Base<Derived>>
                  Quaternion(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
 
     //m = Derived(Translation::Random(), Quaternion::UnitRandom());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SE3Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SE3Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.template tail<4>().norm()-Scalar(1)) <
+                Constants<Scalar>::eps_s,
+                "SE3 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/se3/SE3_map.h
+++ b/include/manif/impl/se3/SE3_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SE3)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so2/SO2.h
+++ b/include/manif/impl/so2/SO2.h
@@ -63,21 +63,22 @@ public:
   using Base::rotation;
   using Base::normalize;
 
+protected:
+
+  using Base::derived;
+
+public:
+
   SO2()  = default;
   ~SO2() = default;
 
+  MANIF_COPY_CONSTRUCTOR(SO2)
+
   // Copy constructor given base
-  SO2(const Base& o);
-
-  template <typename _DerivedOther>
-  SO2(const SO2Base<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   SO2(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO2(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SO2)
 
   /**
    * @brief Constructor given the real and imaginary part
@@ -109,36 +110,8 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO2)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SO2<_Scalar>::SO2(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-               "SO2 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SO2<_Scalar>::SO2(const Base& o)
-  : SO2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO2<_Scalar>::SO2(
-    const SO2Base<_DerivedOther>& o)
-  : SO2(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO2<_Scalar>::SO2(
-    const LieGroupBase<_DerivedOther>& o)
+SO2<_Scalar>::SO2(const LieGroupBase<_DerivedOther>& o)
   : SO2(o.coeffs())
 {
   //

--- a/include/manif/impl/so2/SO2Tangent.h
+++ b/include/manif/impl/so2/SO2Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/so2/SO2Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/so2/SO2Tangent.h
+++ b/include/manif/impl/so2/SO2Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SO2TangentBase<SO2Tangent<_Scalar>>;
   using Type = SO2Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_TANGENT_TYPEDEF
@@ -58,17 +62,13 @@ public:
   SO2Tangent()  = default;
   ~SO2Tangent() = default;
 
-  // Copy constructor given base
-  SO2Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SO2Tangent(const SO2TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SO2Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SO2Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO2Tangent(const Eigen::MatrixBase<_EigenDerived>& theta);
+  MANIF_TANGENT_ASSIGN_OP(SO2Tangent)
 
   //! @brief Constructor given an angle (rad.).
   SO2Tangent(const Scalar theta);
@@ -90,25 +90,8 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SO2Tangent);
 
 template <typename _Scalar>
-SO2Tangent<_Scalar>::SO2Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const SO2TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const TangentBase<_DerivedOther>& o)
+SO2Tangent<_Scalar>::SO2Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
 {
   //
@@ -116,15 +99,6 @@ SO2Tangent<_Scalar>::SO2Tangent(
 
 template <typename _Scalar>
 SO2Tangent<_Scalar>::SO2Tangent(const Scalar theta)
-  : data_(theta)
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO2Tangent<_Scalar>::SO2Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& theta)
   : data_(theta)
 {
   //

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -29,8 +29,15 @@ public:
 
   using Base::coeffs;
 
-  SO2TangentBase()  = default;
-  ~SO2TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO2TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SO2TangentBase)
 
   // Tangent common API
 

--- a/include/manif/impl/so2/SO2Tangent_map.h
+++ b/include/manif/impl/so2/SO2Tangent_map.h
@@ -48,6 +48,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SO2Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -35,6 +35,16 @@ public:
 
   // LieGroup common API
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO2Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SO2Base)
+
   /**
    * @brief Get the inverse of this.
    * @param[out] -optional- J_minv_m Jacobian of the inverse wrt this.
@@ -309,6 +319,21 @@ struct RandomEvaluatorImpl<SO2Base<Derived>>
   {
     using Tangent = typename LieGroupBase<Derived>::Tangent;
     m = Tangent::Random().exp();
+  }
+};
+
+//! @brief Assignment assert specialization for SO2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SO2Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SO2Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                "SO2 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/so2/SO2_map.h
+++ b/include/manif/impl/so2/SO2_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SO2)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so3/SO3.h
+++ b/include/manif/impl/so3/SO3.h
@@ -57,6 +57,10 @@ private:
 
   using QuaternionDataType = Eigen::Quaternion<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -71,18 +75,13 @@ public:
   SO3()  = default;
   ~SO3() = default;
 
+  MANIF_COPY_CONSTRUCTOR(SO3)
+
   // Copy constructor given base
-  SO3(const Base& o);
-
-  template <typename _DerivedOther>
-  SO3(const SO3Base<_DerivedOther>& o);
-
   template <typename _DerivedOther>
   SO3(const LieGroupBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO3(const Eigen::MatrixBase<_EigenDerived>& data);
+  MANIF_GROUP_ASSIGN_OP(SO3)
 
   /**
    * @brief Constructor given a unit quaternion.
@@ -124,42 +123,12 @@ protected:
 MANIF_EXTRA_GROUP_TYPEDEF(SO3)
 
 template <typename _Scalar>
-template <typename _EigenDerived>
-SO3<_Scalar>::SO3(const Eigen::MatrixBase<_EigenDerived>& data)
-  : data_(data)
-{
-  using std::abs;
-  MANIF_ASSERT(abs(data_.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
-               "SO3 constructor argument not normalized !",
-               invalid_argument);
-}
-
-template <typename _Scalar>
-SO3<_Scalar>::SO3(const Base& o)
-  : SO3(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO3<_Scalar>::SO3(
-    const SO3Base<_DerivedOther>& o)
+SO3<_Scalar>::SO3(const LieGroupBase<_DerivedOther>& o)
   : SO3(o.coeffs())
 {
   //
 }
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO3<_Scalar>::SO3(
-    const LieGroupBase<_DerivedOther>& o)
-  : SO3(o.coeffs())
-{
-  //
-}
-
-
 
 template <typename _Scalar>
 SO3<_Scalar>::SO3(const QuaternionDataType& q)

--- a/include/manif/impl/so3/SO3Tangent.h
+++ b/include/manif/impl/so3/SO3Tangent.h
@@ -3,8 +3,6 @@
 
 #include "manif/impl/so3/SO3Tangent_base.h"
 
-#include <Eigen/Core>
-
 namespace manif {
 namespace internal {
 

--- a/include/manif/impl/so3/SO3Tangent.h
+++ b/include/manif/impl/so3/SO3Tangent.h
@@ -49,6 +49,10 @@ private:
   using Base = SO3TangentBase<SO3Tangent<_Scalar>>;
   using Type = SO3Tangent<_Scalar>;
 
+protected:
+
+  using Base::derived;
+
 public:
 
   MANIF_MAKE_ALIGNED_OPERATOR_NEW_COND
@@ -60,17 +64,13 @@ public:
   SO3Tangent()  = default;
   ~SO3Tangent() = default;
 
-  // Copy constructor given base
-  SO3Tangent(const Base& o);
-  template <typename _DerivedOther>
-  SO3Tangent(const SO3TangentBase<_DerivedOther>& o);
+  MANIF_COPY_CONSTRUCTOR(SO3Tangent)
 
+  // Copy constructor given base
   template <typename _DerivedOther>
   SO3Tangent(const TangentBase<_DerivedOther>& o);
 
-  // Copy constructor given Eigen
-  template <typename _EigenDerived>
-  SO3Tangent(const Eigen::MatrixBase<_EigenDerived>& v);
+  MANIF_TANGENT_ASSIGN_OP(SO3Tangent)
 
   // Tangent common API
 
@@ -87,35 +87,9 @@ protected:
 MANIF_EXTRA_TANGENT_TYPEDEF(SO3Tangent);
 
 template <typename _Scalar>
-SO3Tangent<_Scalar>::SO3Tangent(const Base& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
 template <typename _DerivedOther>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const SO3TangentBase<_DerivedOther>& o)
+SO3Tangent<_Scalar>::SO3Tangent(const TangentBase<_DerivedOther>& o)
   : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _DerivedOther>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const TangentBase<_DerivedOther>& o)
-  : data_(o.coeffs())
-{
-  //
-}
-
-template <typename _Scalar>
-template <typename _EigenDerived>
-SO3Tangent<_Scalar>::SO3Tangent(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-  : data_(v)
 {
   //
 }

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -31,8 +31,15 @@ public:
 
   using Base::coeffs;
 
-  SO3TangentBase()  = default;
-  ~SO3TangentBase() = default;
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO3TangentBase)
+
+public:
+
+  MANIF_TANGENT_ML_ASSIGN_OP(SO3TangentBase)
 
   /**
    * @brief Hat operator of SO3.

--- a/include/manif/impl/so3/SO3Tangent_map.h
+++ b/include/manif/impl/so3/SO3Tangent_map.h
@@ -50,6 +50,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_TANGENT_MAP_ASSIGN_OP(SO3Tangent)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -35,6 +35,16 @@ public:
   using Transformation = typename internal::traits<_Derived>::Transformation;
   using QuaternionDataType = Eigen::Quaternion<Scalar>;
 
+protected:
+
+  using Base::derived;
+
+  MANIF_DEFAULT_CONSTRUCTOR(SO3Base)
+
+public:
+
+  MANIF_GROUP_ML_ASSIGN_OP(SO3Base)
+
   // LieGroup common API
 
   /**
@@ -378,6 +388,21 @@ struct RandomEvaluatorImpl<SO3Base<Derived>>
 
 
     // m = Derived(Quaternion::UnitRandom());
+  }
+};
+
+//! @brief Assignment assert specialization for SE2Base objects
+template <typename Derived>
+struct AssignmentEvaluatorImpl<SO3Base<Derived>>
+{
+  template <typename T>
+  static void run_impl(const T& data)
+  {
+    using std::abs;
+    using Scalar = typename SO3Base<Derived>::Scalar;
+    MANIF_CHECK(abs(data.norm()-Scalar(1)) < Constants<Scalar>::eps_s,
+                "SO3 assigned data not normalized !",
+                invalid_argument);
   }
 };
 

--- a/include/manif/impl/so3/SO3_map.h
+++ b/include/manif/impl/so3/SO3_map.h
@@ -51,6 +51,8 @@ public:
 
   Map(Scalar* coeffs) : data_(coeffs) { }
 
+  MANIF_GROUP_MAP_ASSIGN_OP(SO3)
+
   DataType& coeffs() { return data_; }
   const DataType& coeffs() const { return data_; }
 

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -39,10 +39,35 @@ struct TangentBase
   template <typename _Scalar>
   using TangentTemplate = typename internal::traitscast<Tangent, _Scalar>::cast;
 
+protected:
+
+  MANIF_DEFAULT_CONSTRUCTOR(TangentBase)
+
 public:
 
-  TangentBase()  = default;
-  ~TangentBase() = default;
+  /**
+   * @brief Assignment operator.
+   * @param[in] t An element of the same Tangent group.
+   * @return A reference to this.
+   */
+  _Derived& operator =(const TangentBase& t);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] t An element of the same Tangent group.
+   * @return A reference to this.
+   */
+  template <typename _DerivedOther>
+  _Derived& operator =(const TangentBase<_DerivedOther>& t);
+
+  /**
+   * @brief Assignment operator.
+   * @param[in] t A DataType object.
+   * @return A reference to this.
+   * @see DataType.
+   */
+  template <typename _EigenDerived>
+  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
 
   //! @brief Access the underlying data by reference
   DataType& coeffs();
@@ -258,30 +283,6 @@ public:
 
   // Copy assignment
 
-  /**
-   * @brief Assignment operator.
-   * @param[in] t An element of the same Tangent group.
-   * @return A reference to this.
-   */
-  _Derived& operator =(const TangentBase<_Derived>& t);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] t An element of the same Tangent group.
-   * @return A reference to this.
-   */
-  template <typename _DerivedOther>
-  _Derived& operator =(const TangentBase<_DerivedOther>& t);
-
-  /**
-   * @brief Assignment operator.
-   * @param[in] t A DataType object.
-   * @return A reference to this.
-   * @see DataType.
-   */
-  template <typename _EigenDerived>
-  _Derived& operator =(const Eigen::MatrixBase<_EigenDerived>& v);
-
   template <typename T>
   auto operator <<(T&& v)
   ->decltype( std::declval<DataType>().operator<<(std::forward<T>(v)) );
@@ -332,11 +333,39 @@ public:
   //! Static helper to get a Basis of the Lie group.
   static InnerWeight W();
 
-private:
+protected:
 
-  _Derived& derived() { return *static_cast< _Derived* >(this); }
-  const _Derived& derived() const { return *static_cast< const _Derived* >(this); }
+  inline _Derived& derived() & noexcept { return *static_cast< _Derived* >(this); }
+  inline const _Derived& derived() const & noexcept { return *static_cast< const _Derived* >(this); }
 };
+
+// Copy
+
+template <typename _Derived>
+_Derived&
+TangentBase<_Derived>::operator =(const TangentBase& t)
+{
+  coeffs() = t.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+_Derived&
+TangentBase<_Derived>::operator =(const TangentBase<_DerivedOther>& t)
+{
+  coeffs() = t.coeffs();
+  return derived();
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+_Derived&
+TangentBase<_Derived>::operator =(const Eigen::MatrixBase<_EigenDerived>& v)
+{
+  coeffs() = v;
+  return derived();
+}
 
 template <typename _Derived>
 typename TangentBase<_Derived>::DataType&
@@ -604,36 +633,6 @@ bool TangentBase<_Derived>::isApprox(
 }
 
 // Operators
-
-// Copy assignment
-
-template <typename _Derived>
-_Derived&
-TangentBase<_Derived>::operator =(
-    const TangentBase<_Derived>& t)
-{
-  coeffs() = t.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _DerivedOther>
-_Derived&
-TangentBase<_Derived>::operator =(
-    const TangentBase<_DerivedOther>& t)
-{
-  coeffs() = t.coeffs();
-  return derived();
-}
-
-template <typename _Derived>
-template <typename _EigenDerived>
-_Derived& TangentBase<_Derived>::operator =(
-    const Eigen::MatrixBase<_EigenDerived>& v)
-{
-  coeffs() = v;
-  return derived();
-}
 
 template <typename _Derived>
 template <typename T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,9 @@ add_subdirectory(se2)
 # SE3 tests
 add_subdirectory(se3)
 
+# DHu tests
+add_subdirectory(dhu)
+
 find_package(Ceres QUIET)
 
 if(CERES_FOUND)

--- a/test/dhu/CMakeLists.txt
+++ b/test/dhu/CMakeLists.txt
@@ -1,0 +1,13 @@
+# DHu tests
+
+manif_add_gtest(gtest_dhu gtest_dhu.cpp)
+
+set(CXX_11_TEST_TARGETS
+
+  ${CXX_11_TEST_TARGETS}
+
+  # DHu
+  gtest_dhu
+
+  PARENT_SCOPE
+)

--- a/test/dhu/gtest_dhu.cpp
+++ b/test/dhu/gtest_dhu.cpp
@@ -1,0 +1,168 @@
+#include <gtest/gtest.h>
+
+#include "manif/DHu.h"
+
+#include "../common_tester.h"
+
+using namespace manif;
+
+TEST(TEST_DHU, TEST_DHU_CONSTRUCTOR_DATATYPE)
+{
+  DHud dhu((DHud::DataType() << 0,0,0,1,0,0,0,0).finished());
+
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(2));
+  EXPECT_DOUBLE_EQ(1, dhu.coeffs()(3));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(4));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(5));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(6));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(7));
+}
+
+TEST(TEST_DHU, TEST_DHU_CONSTRUCTOR_QUAT)
+{
+  Eigen::Quaterniond real(1,0,0,0), dual(0,0,0,0);
+  DHud dhu(real, dual);
+
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(2));
+  EXPECT_DOUBLE_EQ(1, dhu.coeffs()(3));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(4));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(5));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(6));
+  EXPECT_DOUBLE_EQ(0, dhu.coeffs()(7));
+
+  EXPECT_EIGEN_NEAR(dhu.real().coeffs(), real.coeffs());
+  EXPECT_EIGEN_NEAR(dhu.dual().coeffs(), dual.coeffs());
+}
+
+// TEST(TEST_DHU, TEST_DHU_IDENTITY)
+// {
+//   DHud dhu;
+
+//   dhu.setIdentity();
+
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(0));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(1));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(2));
+//   EXPECT_DOUBLE_EQ(1, dhu.coeffs()(3));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(4));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(5));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(6));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(7));
+// }
+
+// TEST(TEST_DHU, TEST_DHU_IDENTITY2)
+// {
+//   const DHud dhu = DHud::Identity();
+
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(0));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(1));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(2));
+//   EXPECT_DOUBLE_EQ(1, dhu.coeffs()(3));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(4));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(5));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(6));
+//   EXPECT_DOUBLE_EQ(0, dhu.coeffs()(7));
+// }
+
+TEST(TEST_DHU, TEST_DHU_INVERSE)
+{
+  // inverse of identity is identity
+  // DHud dhu = DHud::Identity();
+  DHud dhu((DHud::DataType() << 0,0,0,1,0,0,0,0).finished());
+
+  auto dhu_inv = dhu.inverse();
+
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(2));
+  EXPECT_DOUBLE_EQ(1, dhu_inv.coeffs()(3));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(4));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(5));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(6));
+  EXPECT_DOUBLE_EQ(0, dhu_inv.coeffs()(7));
+
+  // inverse of random in quaternion form is conjugate
+  EXPECT_NO_THROW(
+    dhu = DHud::Random();
+  );
+
+  EXPECT_NO_THROW(
+    dhu_inv = dhu.inverse();
+  );
+
+  DHud I((DHud::DataType() << 0,0,0,1,0,0,0,0).finished());
+
+  EXPECT_MANIF_NEAR(I, dhu*dhu_inv);
+  EXPECT_MANIF_NEAR(I, dhu_inv*dhu);
+}
+
+#ifndef MANIF_NO_DEBUG
+
+TEST(TEST_DHU, TEST_DHU_CONSTRUCTOR_NOT_NORMALIZED_ARGS)
+{
+  EXPECT_THROW(
+    DHud dhu((DHud::DataType() << 1,1,1,1,0,0,0,0).finished()),
+    manif::invalid_argument
+  );
+
+  EXPECT_THROW(
+    DHud dhu((DHud::DataType() << 0,0,0,1,1,1,1,1).finished()),
+    manif::invalid_argument
+  );
+
+  try {
+    DHud dhu((DHud::DataType() << 1,1,1,1,0,0,0,0).finished());
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(std::string(e.what()).empty());
+  }
+}
+
+TEST(TEST_DHU, TEST_DHU_CONSTRUCTOR_UNNORMALIZED)
+{
+  using DataType = typename DHud::DataType;
+  EXPECT_THROW(
+    DHud(DataType::Random()*10.), manif::invalid_argument
+  );
+}
+
+TEST(TEST_DHU, TEST_DHU_NORMALIZE)
+{
+  using DataType = DHud::DataType;
+  DataType data = DataType::Random() * 100.;
+
+  EXPECT_THROW(
+    DHud a(data), manif::invalid_argument
+  );
+
+  Eigen::Map<DHud> map(data.data());
+  map.normalize();
+
+  EXPECT_NO_THROW(
+    DHud b = map
+  );
+
+  try {
+    DHud b = map;
+  } catch (manif::invalid_argument& e) {
+    EXPECT_FALSE(true) << e.what();
+  }
+}
+
+#endif
+
+// MANIF_TEST(DHud);
+
+// MANIF_TEST_MAP(DHud);
+
+// MANIF_TEST_JACOBIANS(DHud);
+
+int main(int argc, char** argv)
+{
+  std::srand((unsigned int) time(0));
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/eigen_gtest.h
+++ b/test/eigen_gtest.h
@@ -2,7 +2,6 @@
 #define _MANIF_TEST_EIGEN_GTEST_H_
 
 #include <gtest/gtest.h>
-#include <Eigen/Dense>
 
 namespace manif {
 namespace detail {

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -3,8 +3,6 @@
 #include "manif/SE3.h"
 #include "../common_tester.h"
 
-#include <Eigen/Geometry>
-
 using namespace manif;
 
 TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_DATATYPE)
@@ -234,7 +232,7 @@ TEST(TEST_SE3, TEST_SE3_INVERSE)
 
   se3 = SE3d::Random();
 
-  Eigen::Isometry3d iso(se3.asSO3().quat());
+  Eigen::Isometry3d iso(se3.quat());
   iso.translation() = se3.translation();
 
   EXPECT_EIGEN_NEAR(iso.matrix(), se3.transform());


### PR DESCRIPTION
This PR adds the unit dual quaternion group,  currently called `DHu`.

Draft implementation:

+ [x] `DHu::Random`
+ [x] `DHu::Inverse`
+ [x] `DHu::Compose`
+ [x] `DHu::normalize`
+ [x] `DHu::normalize`
+ [x] `DHu::normalize`

Comes on top of #150.

Closes #164.