### PR TITLE
[SE(3)] Add setters for translation and rotation 

### DIFF
--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -234,13 +234,7 @@ SE3Base<_Derived>::translation() const
 template <typename _Derived>
 void SE3Base<_Derived>::quat(const QuaternionDataType& quaternion)
 {
-  using std::abs;
-  MANIF_ASSERT(abs(quaternion.template norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
-               "The quaternion is not normalized !",
-               invalid_argument);
-
-  asSO3().coeffs() = quaternion.coeffs();
+  quat(quaternion.coeffs());
 }
 
 template <typename _Derived>

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -155,6 +155,31 @@ public:
    */
   void normalize();
 
+  /**
+   * @brief Set the rotational as a quaternion.
+   * @param quaternion a unitary quaternion
+   */
+  void quat(const QuaternionDataType& quaternion);
+
+  /**
+   * @brief Set the rotational as a quaternion.
+   * @param quaternion an Eigen::Vector representing a quaternion
+   */
+  template <typename _EigenDerived>
+  void quat(const Eigen::MatrixBase<_EigenDerived> &quaternion);
+
+  /**
+   * @brief Set the rotational as a so3 object.
+   * @param so3 a manif::SO3 object
+   */
+  void quat(const SO3<Scalar>& so3);
+
+  /**
+   * @brief Set the translation of the SE3 object
+   * @param translation, 3d-vector representing the translation
+   */
+  void translation(const Translation& translation);
+
 public: /// @todo make protected
 
   Eigen::Map<const SO3<Scalar>> asSO3() const
@@ -204,6 +229,43 @@ typename SE3Base<_Derived>::Translation
 SE3Base<_Derived>::translation() const
 {
   return coeffs().template head<3>();
+}
+
+template <typename _Derived>
+void SE3Base<_Derived>::quat(const SE3Base<_Derived>::QuaternionDataType& quaternion)
+{
+  using std::abs;
+  MANIF_ASSERT(abs(quaternion.template norm()-Scalar(1)) <
+               Constants<Scalar>::eps_s,
+               "The quaternion is not normalized !",
+               invalid_argument);
+
+  asSO3().coeffs() = quaternion.coeffs();
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+void SE3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived> &quaternion)
+{
+  assert_vector_dim(quaternion, 4);
+  MANIF_ASSERT(abs(quaternion.template norm()-Scalar(1)) <
+               Constants<Scalar>::eps_s,
+               "The quaternion is not normalized !",
+               invalid_argument);
+
+  asSO3().coeffs() = quaternion;
+}
+
+template <typename _Derived>
+void SE3Base<_Derived>::quat(const SO3<Scalar>& so3)
+{
+  quat(so3.quat());
+}
+
+template <typename _Derived>
+void SE3Base<_Derived>::translation(const Translation& translation)
+{
+  coeffs().template head<3>() = translation;
 }
 
 template <typename _Derived>

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -163,10 +163,10 @@ public:
 
   /**
    * @brief Set the rotational as a quaternion.
-   * @param quaternion an Eigen::Vector representing a quaternion
+   * @param quaternion an Eigen::Vector representing a unitary quaternion
    */
   template <typename _EigenDerived>
-  void quat(const Eigen::MatrixBase<_EigenDerived> &quaternion);
+  void quat(const Eigen::MatrixBase<_EigenDerived>& quaternion);
 
   /**
    * @brief Set the rotational as a so3 object.
@@ -232,7 +232,7 @@ SE3Base<_Derived>::translation() const
 }
 
 template <typename _Derived>
-void SE3Base<_Derived>::quat(const SE3Base<_Derived>::QuaternionDataType& quaternion)
+void SE3Base<_Derived>::quat(const QuaternionDataType& quaternion)
 {
   using std::abs;
   MANIF_ASSERT(abs(quaternion.template norm()-Scalar(1)) <
@@ -245,8 +245,9 @@ void SE3Base<_Derived>::quat(const SE3Base<_Derived>::QuaternionDataType& quater
 
 template <typename _Derived>
 template <typename _EigenDerived>
-void SE3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived> &quaternion)
+void SE3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived>& quaternion)
 {
+  using std::abs;
   assert_vector_dim(quaternion, 4);
   MANIF_ASSERT(abs(quaternion.template norm()-Scalar(1)) <
                Constants<Scalar>::eps_s,

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -254,7 +254,7 @@ void SE3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived>& quaternion)
 template <typename _Derived>
 void SE3Base<_Derived>::quat(const SO3<Scalar>& so3)
 {
-  quat(so3.quat());
+  quat(so3.coeffs());
 }
 
 template <typename _Derived>

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -106,6 +106,77 @@ TEST(TEST_SE3, TEST_SE3_DATA)
   EXPECT_DOUBLE_EQ(1, *data_ptr);
 }
 
+TEST(TEST_SE3, TEST_SE3_SET_AXIS_ANGLE)
+{
+  SE3d::DataType values; values << 0,0,0, 0,0,0,1;
+  SE3d se3(values);
+
+  Eigen::AngleAxis<double> axisAngle(0.23, Eigen::Vector3d::UnitZ());
+  Eigen::Quaterniond quat(axisAngle);
+
+  se3.quat(axisAngle);
+
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(0), se3.coeffs()(3));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(1), se3.coeffs()(4));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(2), se3.coeffs()(5));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(3), se3.coeffs()(6));
+}
+
+TEST(TEST_SE3, TEST_SE3_SET_QUATERNION)
+{
+  SE3d::DataType values; values << 0,0,0, 0,0,0,1;
+  SE3d se3(values);
+
+  Eigen::AngleAxis<double> axisAngle(0.23, Eigen::Vector3d::UnitZ());
+  Eigen::Quaterniond quat(axisAngle);
+
+  se3.quat(quat);
+
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(0), se3.coeffs()(3));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(1), se3.coeffs()(4));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(2), se3.coeffs()(5));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(3), se3.coeffs()(6));
+}
+
+TEST(TEST_SE3, TEST_SE3_SET_SO3)
+{
+  SE3d::DataType values; values << 0,0,0, 0,0,0,1;
+  SE3d se3(values);
+  SO3d so3(Eigen::AngleAxis<double>(0.23, Eigen::Vector3d::UnitZ()));
+
+  se3.quat(so3);
+
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(so3.coeffs()(0), se3.coeffs()(3));
+  EXPECT_DOUBLE_EQ(so3.coeffs()(1), se3.coeffs()(4));
+  EXPECT_DOUBLE_EQ(so3.coeffs()(2), se3.coeffs()(5));
+  EXPECT_DOUBLE_EQ(so3.coeffs()(3), se3.coeffs()(6));
+}
+
+TEST(TEST_SE3, TEST_SE3_SET_TRANSLATION)
+{
+  SE3d::DataType values; values << 0,0,0, 0,0,0,1;
+  SE3d se3(values);
+
+  se3.translation(Eigen::Vector3d(1,1,1));
+
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(3));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(4));
+  EXPECT_DOUBLE_EQ(0, se3.coeffs()(5));
+  EXPECT_DOUBLE_EQ(1, se3.coeffs()(6));
+}
+
 TEST(TEST_SE3, TEST_SE3_CAST)
 {
   SE3d se3d(SE3d::Translation(1,2,3),


### PR DESCRIPTION
This PR implements the setters for the SE(3) object. Specifically, it implements two functions `quat()` and `translation()` to set the rotation and the translation to an already existing SE(3) object. 

The `quat()` methods checks if the quaternion has unitary norm, if not an exception is thrown. 

This PR closes #160 