### PR TITLE
Disambiguate w -> innerWeights

### DIFF
--- a/include/manif/impl/generator.h
+++ b/include/manif/impl/generator.h
@@ -17,25 +17,25 @@ struct GeneratorEvaluator
 };
 
 template <typename Derived>
-struct WEvaluator
+struct InnerWeightsEvaluator
 {
-  static typename Derived::InnerWeight
+  static typename Derived::InnerWeightsMatrix
   run()
   {
-    using InnerWeight = typename Derived::InnerWeight;
+    using InnerWeightsMatrix = typename Derived::InnerWeightsMatrix;
 
     auto computeW = []()
     {
-      InnerWeight W = InnerWeight::Zero();
+      InnerWeightsMatrix W = InnerWeightsMatrix::Zero();
 
-      for (int r=0; r<Derived::DoF; ++r)
-        for (int c=0; c<Derived::DoF; ++c)
-          W(r,c) = (Derived::Generator(r)*Derived::Generator(c).transpose()).trace();
+      for (int r = 0; r <Derived::DoF; ++r)
+        for (int c = 0; c < Derived::DoF; ++c)
+          W(r,c) = (Derived::Generator(r) * Derived::Generator(c).transpose()).trace();
 
       return W;
     };
 
-    const static InnerWeight W = computeW();
+    const static InnerWeightsMatrix W = computeW();
 
     return W;
   }

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -340,18 +340,19 @@ struct GeneratorEvaluator<SE2TangentBase<Derived>>
 
 //! @brief Inner weight matrix specialization for SE2TangentBase objects.
 template <typename Derived>
-struct WEvaluator<SE2TangentBase<Derived>>
+struct InnerWeightsEvaluator<SE2TangentBase<Derived>>
 {
-  static typename Derived::Jacobian
+  static typename Derived::InnerWeightsMatrix
   run()
   {
-    using Jacobian = typename SE2TangentBase<Derived>::Jacobian;
-    using Scalar   = typename SE2TangentBase<Derived>::Scalar;
+    using InnerWeightsMatrix = typename SE2TangentBase<Derived>::InnerWeightsMatrix;
+    using Scalar = typename SE2TangentBase<Derived>::Scalar;
 
-    const static Jacobian W(
-            (Jacobian() << Scalar(1), Scalar(0), Scalar(0),
-                           Scalar(0), Scalar(1), Scalar(0),
-                           Scalar(0), Scalar(0), Scalar(2) ).finished());
+    const static InnerWeightsMatrix W(
+      (InnerWeightsMatrix() << Scalar(1), Scalar(0), Scalar(0),
+                               Scalar(0), Scalar(1), Scalar(0),
+                               Scalar(0), Scalar(0), Scalar(2) ).finished()
+    );
 
     return W;
   }

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -32,7 +32,7 @@ struct TangentBase
   using Jacobian = typename internal::traits<_Derived>::Jacobian;
   using LieAlg   = typename internal::traits<_Derived>::LieAlg;
 
-  using InnerWeight = Jacobian;
+  using InnerWeightsMatrix = Jacobian;
 
   using OptJacobianRef = tl::optional<Eigen::Ref<Jacobian>>;
 
@@ -113,14 +113,14 @@ public:
    * @return the weight matrix.
    * @see generator
    */
-  InnerWeight w() const;
+  InnerWeightsMatrix innerWeights() const;
 
   /**
    * @brief Get inner product of this and another Tangent
    * weightedby W.
    * @return The inner product of this and t.
    * @note ip = v0' . W . v1
-   * @see w()
+   * @see innerWeights()
    */
   template <typename _DerivedOther>
   Scalar inner(const TangentBase<_DerivedOther>& t) const;
@@ -128,7 +128,7 @@ public:
   /**
    * @brief Get the Euclidean weighted norm.
    * @return The Euclidean weighted norm.
-   * @see w()
+   * @see innerWeights()
    * @see squaredWeightedNorm()
    */
   Scalar weightedNorm() const;
@@ -136,7 +136,7 @@ public:
   /**
    * @brief Get the squared Euclidean weighted norm.
    * @return The squared Euclidean weighted norm.
-   * @see w()
+   * @see innerWeights()
    * @see WeightedNorm()
    */
   Scalar squaredWeightedNorm() const;
@@ -329,7 +329,7 @@ public:
   //! Static helper to get a Basis of the Lie group.
   static LieAlg Generator(const int i);
   //! Static helper to get a Basis of the Lie group.
-  static InnerWeight W();
+  static InnerWeightsMatrix InnerWeights();
 
 protected:
 
@@ -440,10 +440,10 @@ TangentBase<_Derived>::generator(const int i) const
 }
 
 template <typename _Derived>
-typename TangentBase<_Derived>::InnerWeight
-TangentBase<_Derived>::w() const
+typename TangentBase<_Derived>::InnerWeightsMatrix
+TangentBase<_Derived>::innerWeights() const
 {
-  return W();
+  return InnerWeights();
 }
 
 template <typename _Derived>
@@ -451,7 +451,7 @@ template <typename _DerivedOther>
 typename TangentBase<_Derived>::Scalar
 TangentBase<_Derived>::inner(const TangentBase<_DerivedOther>& t) const
 {
-  return (coeffs().transpose() * W() * t.coeffs())(0);
+  return (coeffs().transpose() * InnerWeights() * t.coeffs())(0);
 }
 
 template <class _Derived>
@@ -466,7 +466,7 @@ template <class _Derived>
 typename TangentBase<_Derived>::Scalar
 TangentBase<_Derived>::squaredWeightedNorm() const
 {
-  return (coeffs().transpose() * W() * coeffs())(0);
+  return (coeffs().transpose() * InnerWeights() * coeffs())(0);
 }
 
 template <class _Derived>
@@ -666,10 +666,10 @@ TangentBase<_Derived>::Generator(const int i)
 }
 
 template <typename _Derived>
-typename TangentBase<_Derived>::InnerWeight
-TangentBase<_Derived>::W()
+typename TangentBase<_Derived>::InnerWeightsMatrix
+TangentBase<_Derived>::InnerWeights()
 {
-  return internal::WEvaluator<
+  return internal::InnerWeightsEvaluator<
       typename internal::traits<_Derived>::Base>::run();
 }
 


### PR DESCRIPTION
Disambiguate
- `Tangent::w` and rename it `Tangent::innerWeights`
- `Tangent::W` and rename it `Tangent::InnerWeights`

After discussing it [here](https://github.com/artivis/manif/pull/179#issuecomment-747944038).