### PR TITLE
Disambiguate v/w/a -> lin/ang/lin2

### DIFF
--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -28,10 +28,10 @@ public:
   MANIF_TANGENT_TYPEDEF
   MANIF_INHERIT_TANGENT_OPERATOR
 
-  using LinVel = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using ConstLinVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using LinBlock = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using AngBlock = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstLinBlock = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using ConstAngBlock = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
 
   using Base::data;
   using Base::coeffs;
@@ -105,12 +105,12 @@ public:
   // SE3Tangent specific API
 
   //! @brief Get the linear part.
-  LinVel linVel();
-  const ConstLinVel linVel() const;
+  LinBlock lin();
+  const ConstLinBlock lin() const;
 
   //! @brief Get the angular part.
-  AngVel angVel();
-  const ConstAngVel angVel() const;
+  AngBlock ang();
+  const ConstAngBlock ang() const;
 
 //  Scalar x() const;
 //  Scalar y() const;
@@ -153,7 +153,7 @@ SE3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   }
 
   /// @note Eq. 10.93
-  return LieGroup(asSO3().ljac()*linVel(), asSO3().exp().quat());
+  return LieGroup(asSO3().ljac()*lin(), asSO3().exp().quat());
 }
 
 template <typename _Derived>
@@ -310,8 +310,8 @@ SE3TangentBase<_Derived>::smallAdj() const
   /// considering vee(log(g)) = (v;w)
 
   Jacobian smallAdj;
-  smallAdj.template topRightCorner<3,3>() = skew(linVel());
-  smallAdj.template topLeftCorner<3,3>() = skew(angVel());
+  smallAdj.template topRightCorner<3,3>() = skew(lin());
+  smallAdj.template topLeftCorner<3,3>() = skew(ang());
   smallAdj.template bottomRightCorner<3,3>() = smallAdj.template topLeftCorner<3,3>();
   smallAdj.template bottomLeftCorner<3,3>().setZero();
 
@@ -321,29 +321,29 @@ SE3TangentBase<_Derived>::smallAdj() const
 // SE3Tangent specific API
 
 template <typename _Derived>
-typename SE3TangentBase<_Derived>::LinVel
-SE3TangentBase<_Derived>::linVel()
+typename SE3TangentBase<_Derived>::LinBlock
+SE3TangentBase<_Derived>::lin()
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-const typename SE3TangentBase<_Derived>::ConstLinVel
-SE3TangentBase<_Derived>::linVel() const
+const typename SE3TangentBase<_Derived>::ConstLinBlock
+SE3TangentBase<_Derived>::lin() const
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-typename SE3TangentBase<_Derived>::AngVel
-SE3TangentBase<_Derived>::angVel()
+typename SE3TangentBase<_Derived>::AngBlock
+SE3TangentBase<_Derived>::ang()
 {
   return coeffs().template tail<3>();
 }
 
 template <typename _Derived>
-const typename SE3TangentBase<_Derived>::ConstAngVel
-SE3TangentBase<_Derived>::angVel() const
+const typename SE3TangentBase<_Derived>::ConstAngBlock
+SE3TangentBase<_Derived>::ang() const
 {
   return coeffs().template tail<3>();
 }

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -28,10 +28,10 @@ public:
   MANIF_TANGENT_TYPEDEF
   MANIF_INHERIT_TANGENT_OPERATOR
 
-  using BlockV = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using BlockW = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using ConstBlockV = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstBlockW = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using LinVel = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstLinVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
 
   using Base::data;
   using Base::coeffs;
@@ -105,12 +105,12 @@ public:
   // SE3Tangent specific API
 
   //! @brief Get the linear part.
-  BlockV v();
-  const ConstBlockV v() const;
+  LinVel linVel();
+  const ConstLinVel linVel() const;
 
   //! @brief Get the angular part.
-  BlockW w();
-  const ConstBlockW w() const;
+  AngVel angVel();
+  const ConstAngVel angVel() const;
 
 //  Scalar x() const;
 //  Scalar y() const;
@@ -153,7 +153,7 @@ SE3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   }
 
   /// @note Eq. 10.93
-  return LieGroup(asSO3().ljac()*v(), asSO3().exp().quat());
+  return LieGroup(asSO3().ljac()*linVel(), asSO3().exp().quat());
 }
 
 template <typename _Derived>
@@ -310,8 +310,8 @@ SE3TangentBase<_Derived>::smallAdj() const
   /// considering vee(log(g)) = (v;w)
 
   Jacobian smallAdj;
-  smallAdj.template topRightCorner<3,3>() = skew(v());
-  smallAdj.template topLeftCorner<3,3>() = skew(w());
+  smallAdj.template topRightCorner<3,3>() = skew(linVel());
+  smallAdj.template topLeftCorner<3,3>() = skew(angVel());
   smallAdj.template bottomRightCorner<3,3>() = smallAdj.template topLeftCorner<3,3>();
   smallAdj.template bottomLeftCorner<3,3>().setZero();
 
@@ -321,28 +321,29 @@ SE3TangentBase<_Derived>::smallAdj() const
 // SE3Tangent specific API
 
 template <typename _Derived>
-typename SE3TangentBase<_Derived>::BlockV
-SE3TangentBase<_Derived>::v()
+typename SE3TangentBase<_Derived>::LinVel
+SE3TangentBase<_Derived>::linVel()
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-const typename SE3TangentBase<_Derived>::ConstBlockV
-SE3TangentBase<_Derived>::v() const
+const typename SE3TangentBase<_Derived>::ConstLinVel
+SE3TangentBase<_Derived>::linVel() const
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-typename SE3TangentBase<_Derived>::BlockW SE3TangentBase<_Derived>::w()
+typename SE3TangentBase<_Derived>::AngVel
+SE3TangentBase<_Derived>::angVel()
 {
   return coeffs().template tail<3>();
 }
 
 template <typename _Derived>
-const typename SE3TangentBase<_Derived>::ConstBlockW
-SE3TangentBase<_Derived>::w() const
+const typename SE3TangentBase<_Derived>::ConstAngVel
+SE3TangentBase<_Derived>::angVel() const
 {
   return coeffs().template tail<3>();
 }

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
@@ -29,12 +29,12 @@ public:
   MANIF_INHERIT_TANGENT_API
   MANIF_INHERIT_TANGENT_OPERATOR
 
-  using BlockV = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using BlockW = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using BlockA = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using ConstBlockV = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstBlockW = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstBlockA = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using LinVel = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using LinAcc = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstLinVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using ConstLinAcc = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
 
   using Base::data;
   using Base::coeffs;
@@ -94,16 +94,16 @@ public:
   // SE_2_3Tangent specific API
 
   //! @brief Get the linear velocity part.
-  BlockV v();
-  const ConstBlockV v() const;
+  LinVel linVel();
+  const ConstLinVel linVel() const;
 
   //! @brief Get the angular part.
-  BlockW w();
-  const ConstBlockW w() const;
+  AngVel angVel();
+  const ConstAngVel angVel() const;
 
   //! @brief Get the linear acceleration part
-  BlockA a();
-  const ConstBlockA a() const;
+  LinAcc linAcc();
+  const ConstLinAcc linAcc() const;
 
 public: /// @todo make protected
 
@@ -128,7 +128,12 @@ SE_2_3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
     *J_m_t = rjac();
   }
 
-  return LieGroup(asSO3().ljac()*v(), asSO3().exp().quat(), asSO3().ljac()*a());
+  const Eigen::Map<const SO3Tangent<Scalar>> so3 = asSO3();
+  const typename SO3<Scalar>::Jacobian so3_ljac = so3.ljac();
+
+  return LieGroup(so3_ljac*linVel(),
+                  so3.exp().quat(),
+                  so3_ljac*linAcc());
 }
 
 template <typename _Derived>
@@ -220,52 +225,54 @@ SE_2_3TangentBase<_Derived>::smallAdj() const
   Jacobian smallAdj;
   smallAdj.template block<6, 3>(3, 0).setZero();
   smallAdj.template block<6, 3>(0, 6).setZero();
-  smallAdj.template block<3,3>(0, 3) = skew(v());
-  smallAdj.template topLeftCorner<3,3>() = skew(w());
+  smallAdj.template block<3,3>(0, 3) = skew(linVel());
+  smallAdj.template topLeftCorner<3,3>() = skew(angVel());
   smallAdj.template block<3,3>(3,3) = smallAdj.template topLeftCorner<3,3>();
   smallAdj.template bottomRightCorner<3,3>() = smallAdj.template topLeftCorner<3,3>();
-  smallAdj.template block<3,3>(6, 3) = skew(a());
+  smallAdj.template block<3,3>(6, 3) = skew(linAcc());
   return smallAdj;
 }
 
 // SE_2_3Tangent specific API
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::BlockV
-SE_2_3TangentBase<_Derived>::v()
+typename SE_2_3TangentBase<_Derived>::LinVel
+SE_2_3TangentBase<_Derived>::linVel()
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstBlockV
-SE_2_3TangentBase<_Derived>::v() const
+const typename SE_2_3TangentBase<_Derived>::ConstLinVel
+SE_2_3TangentBase<_Derived>::linVel() const
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::BlockW SE_2_3TangentBase<_Derived>::w()
+typename SE_2_3TangentBase<_Derived>::AngVel
+SE_2_3TangentBase<_Derived>::angVel()
 {
   return coeffs().template segment<3>(3);
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstBlockW
-SE_2_3TangentBase<_Derived>::w() const
+const typename SE_2_3TangentBase<_Derived>::ConstAngVel
+SE_2_3TangentBase<_Derived>::angVel() const
 {
   return coeffs().template segment<3>(3);
 }
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::BlockA SE_2_3TangentBase<_Derived>::a()
+typename SE_2_3TangentBase<_Derived>::LinAcc
+SE_2_3TangentBase<_Derived>::linAcc()
 {
   return coeffs().template tail<3>();
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstBlockA
-SE_2_3TangentBase<_Derived>::a() const
+const typename SE_2_3TangentBase<_Derived>::ConstLinAcc
+SE_2_3TangentBase<_Derived>::linAcc() const
 {
   return coeffs().template tail<3>();
 }

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
@@ -29,12 +29,10 @@ public:
   MANIF_INHERIT_TANGENT_API
   MANIF_INHERIT_TANGENT_OPERATOR
 
-  using LinVel = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using LinAcc = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using ConstLinVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
-  using ConstLinAcc = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using LinBlock = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using AngBlock = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstLinBlock = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using ConstAngBlock = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
 
   using Base::data;
   using Base::coeffs;
@@ -94,16 +92,16 @@ public:
   // SE_2_3Tangent specific API
 
   //! @brief Get the linear velocity part.
-  LinVel linVel();
-  const ConstLinVel linVel() const;
+  LinBlock lin();
+  const ConstLinBlock lin() const;
 
   //! @brief Get the angular part.
-  AngVel angVel();
-  const ConstAngVel angVel() const;
+  AngBlock ang();
+  const ConstAngBlock ang() const;
 
   //! @brief Get the linear acceleration part
-  LinAcc linAcc();
-  const ConstLinAcc linAcc() const;
+  LinBlock lin2();
+  const ConstLinBlock lin2() const;
 
 public: /// @todo make protected
 
@@ -131,9 +129,9 @@ SE_2_3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   const Eigen::Map<const SO3Tangent<Scalar>> so3 = asSO3();
   const typename SO3<Scalar>::Jacobian so3_ljac = so3.ljac();
 
-  return LieGroup(so3_ljac*linVel(),
+  return LieGroup(so3_ljac*lin(),
                   so3.exp().quat(),
-                  so3_ljac*linAcc());
+                  so3_ljac*lin2());
 }
 
 template <typename _Derived>
@@ -225,54 +223,54 @@ SE_2_3TangentBase<_Derived>::smallAdj() const
   Jacobian smallAdj;
   smallAdj.template block<6, 3>(3, 0).setZero();
   smallAdj.template block<6, 3>(0, 6).setZero();
-  smallAdj.template block<3,3>(0, 3) = skew(linVel());
-  smallAdj.template topLeftCorner<3,3>() = skew(angVel());
+  smallAdj.template block<3,3>(0, 3) = skew(lin());
+  smallAdj.template topLeftCorner<3,3>() = skew(ang());
   smallAdj.template block<3,3>(3,3) = smallAdj.template topLeftCorner<3,3>();
   smallAdj.template bottomRightCorner<3,3>() = smallAdj.template topLeftCorner<3,3>();
-  smallAdj.template block<3,3>(6, 3) = skew(linAcc());
+  smallAdj.template block<3,3>(6, 3) = skew(lin2());
   return smallAdj;
 }
 
 // SE_2_3Tangent specific API
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::LinVel
-SE_2_3TangentBase<_Derived>::linVel()
+typename SE_2_3TangentBase<_Derived>::LinBlock
+SE_2_3TangentBase<_Derived>::lin()
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstLinVel
-SE_2_3TangentBase<_Derived>::linVel() const
+const typename SE_2_3TangentBase<_Derived>::ConstLinBlock
+SE_2_3TangentBase<_Derived>::lin() const
 {
   return coeffs().template head<3>();
 }
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::AngVel
-SE_2_3TangentBase<_Derived>::angVel()
+typename SE_2_3TangentBase<_Derived>::AngBlock
+SE_2_3TangentBase<_Derived>::ang()
 {
   return coeffs().template segment<3>(3);
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstAngVel
-SE_2_3TangentBase<_Derived>::angVel() const
+const typename SE_2_3TangentBase<_Derived>::ConstAngBlock
+SE_2_3TangentBase<_Derived>::ang() const
 {
   return coeffs().template segment<3>(3);
 }
 
 template <typename _Derived>
-typename SE_2_3TangentBase<_Derived>::LinAcc
-SE_2_3TangentBase<_Derived>::linAcc()
+typename SE_2_3TangentBase<_Derived>::LinBlock
+SE_2_3TangentBase<_Derived>::lin2()
 {
   return coeffs().template tail<3>();
 }
 
 template <typename _Derived>
-const typename SE_2_3TangentBase<_Derived>::ConstLinAcc
-SE_2_3TangentBase<_Derived>::linAcc() const
+const typename SE_2_3TangentBase<_Derived>::ConstLinBlock
+SE_2_3TangentBase<_Derived>::lin2() const
 {
   return coeffs().template tail<3>();
 }

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -27,8 +27,8 @@ public:
   MANIF_TANGENT_TYPEDEF
   MANIF_INHERIT_TANGENT_OPERATOR
 
-  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
-  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+  using AngBlock = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstAngBlock = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
 
   // Tangent common API
 
@@ -110,8 +110,8 @@ public:
   Scalar z() const;
 
   //! @brief Get the angular part.
-  AngVel angVel();
-  const ConstAngVel angVel() const;
+  AngBlock ang();
+  const ConstAngBlock ang() const;
 };
 
 template <typename _Derived>
@@ -260,15 +260,15 @@ SO3TangentBase<_Derived>::z() const
 }
 
 template <typename _Derived>
-typename SO3TangentBase<_Derived>::AngVel
-SO3TangentBase<_Derived>::angVel()
+typename SO3TangentBase<_Derived>::AngBlock
+SO3TangentBase<_Derived>::ang()
 {
   return coeffs().template tail<3>();
 }
 
 template <typename _Derived>
-const typename SO3TangentBase<_Derived>::ConstAngVel
-SO3TangentBase<_Derived>::angVel() const
+const typename SO3TangentBase<_Derived>::ConstAngBlock
+SO3TangentBase<_Derived>::ang() const
 {
   return coeffs().template tail<3>();
 }

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -27,6 +27,9 @@ public:
   MANIF_TANGENT_TYPEDEF
   MANIF_INHERIT_TANGENT_OPERATOR
 
+  using AngVel = typename DataType::template FixedSegmentReturnType<3>::Type;
+  using ConstAngVel = typename DataType::template ConstFixedSegmentReturnType<3>::Type;
+
   // Tangent common API
 
   using Base::coeffs;
@@ -105,6 +108,10 @@ public:
   Scalar y() const;
   //! @brief
   Scalar z() const;
+
+  //! @brief Get the angular part.
+  AngVel angVel();
+  const ConstAngVel angVel() const;
 };
 
 template <typename _Derived>
@@ -250,6 +257,20 @@ typename SO3TangentBase<_Derived>::Scalar
 SO3TangentBase<_Derived>::z() const
 {
   return coeffs()(2);
+}
+
+template <typename _Derived>
+typename SO3TangentBase<_Derived>::AngVel
+SO3TangentBase<_Derived>::angVel()
+{
+  return coeffs().template tail<3>();
+}
+
+template <typename _Derived>
+const typename SO3TangentBase<_Derived>::ConstAngVel
+SO3TangentBase<_Derived>::angVel() const
+{
+  return coeffs().template tail<3>();
 }
 
 namespace internal {

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -401,6 +401,19 @@ TEST(TEST_SE3, TEST_SE3_ISOMETRY)
   EXPECT_DOUBLE_EQ(3, se3h.matrix()(2,3));
 }
 
+TEST(TEST_SE3, TEST_SE3TAN_LINANGVEL)
+{
+  SE3Tangentd::DataType data;
+  data << 1,2,3,4,5,6;
+  SE3Tangentd se3tan(data);
+
+  EXPECT_EIGEN_NEAR(Eigen::Vector3d(1,2,3),
+                    se3tan.linVel());
+
+  EXPECT_EIGEN_NEAR(Eigen::Vector3d(4,5,6),
+                    se3tan.angVel());
+}
+
 #ifndef MANIF_NO_DEBUG
 
 TEST(TEST_SE3, TEST_SE3_CONSTRUCTOR_NOT_NORMALIZED_ARGS)

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -408,10 +408,10 @@ TEST(TEST_SE3, TEST_SE3TAN_LINANGVEL)
   SE3Tangentd se3tan(data);
 
   EXPECT_EIGEN_NEAR(Eigen::Vector3d(1,2,3),
-                    se3tan.linVel());
+                    se3tan.lin());
 
   EXPECT_EIGEN_NEAR(Eigen::Vector3d(4,5,6),
-                    se3tan.angVel());
+                    se3tan.ang());
 }
 
 #ifndef MANIF_NO_DEBUG

--- a/test/se_2_3/gtest_se_2_3.cpp
+++ b/test/se_2_3/gtest_se_2_3.cpp
@@ -316,13 +316,13 @@ TEST(TEST_SE_2_3, TEST_SE_2_3TAN_LINANGVELACC)
   SE_2_3Tangentd se23tan(data);
 
   EXPECT_EIGEN_NEAR(Eigen::Vector3d(1,2,3),
-                    se23tan.linVel());
+                    se23tan.lin());
 
   EXPECT_EIGEN_NEAR(Eigen::Vector3d(4,5,6),
-                    se23tan.angVel());
+                    se23tan.ang());
 
   EXPECT_EIGEN_NEAR(Eigen::Vector3d(7,8,9),
-                    se23tan.linAcc());
+                    se23tan.lin2());
 }
 
 #ifndef MANIF_NO_DEBUG

--- a/test/se_2_3/gtest_se_2_3.cpp
+++ b/test/se_2_3/gtest_se_2_3.cpp
@@ -309,6 +309,21 @@ TEST(TEST_SE_2_3, TEST_SE_2_3_ACT)
   EXPECT_NEAR( 0, transformed_point.z(), 1e-15);
 }
 
+TEST(TEST_SE_2_3, TEST_SE_2_3TAN_LINANGVELACC)
+{
+  SE_2_3Tangentd::DataType data;
+  data << 1,2,3,4,5,6,7,8,9;
+  SE_2_3Tangentd se23tan(data);
+
+  EXPECT_EIGEN_NEAR(Eigen::Vector3d(1,2,3),
+                    se23tan.linVel());
+
+  EXPECT_EIGEN_NEAR(Eigen::Vector3d(4,5,6),
+                    se23tan.angVel());
+
+  EXPECT_EIGEN_NEAR(Eigen::Vector3d(7,8,9),
+                    se23tan.linAcc());
+}
 
 #ifndef MANIF_NO_DEBUG
 

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -83,7 +83,7 @@ TEST(TEST_SO3, TEST_SO3TAN_ANGVEL)
   SO3Tangentd so3tan(SO3Tangentd::DataType(1,2,3));
 
   EXPECT_EIGEN_NEAR(SO3Tangentd::DataType(1,2,3),
-                    so3tan.angVel());
+                    so3tan.ang());
 }
 
 TEST(TEST_SO3, TEST_SO3_RANDOM)

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -78,6 +78,14 @@ TEST(TEST_SO3, TEST_SO3_IDENTITY2)
   EXPECT_DOUBLE_EQ(1, so3.w());
 }
 
+TEST(TEST_SO3, TEST_SO3TAN_ANGVEL)
+{
+  SO3Tangentd so3tan(SO3Tangentd::DataType(1,2,3));
+
+  EXPECT_EIGEN_NEAR(SO3Tangentd::DataType(1,2,3),
+                    so3tan.angVel());
+}
+
 TEST(TEST_SO3, TEST_SO3_RANDOM)
 {
   SO3d so3;


### PR DESCRIPTION
Disambiguate

- `SO3/SE3/SE_2_3::v` rename it `::lin`
- `SE3/SE_2_3::w` rename it `::ang`
- `SE_2_3::a` rename it `::lin2`

as discussed [here](https://github.com/artivis/manif/pull/179#issuecomment-748513087) and in this PR.