### PR TITLE
Minor fixes: use known inverses, fix ambiguous ternary types

### DIFF
--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -252,7 +252,7 @@ SE2Base<_Derived>::log(OptJacobianRef J_t_m) const
   if (J_t_m)
   {
     // Jr^-1
-    (*J_t_m) = tan.rjac().inverse();
+    (*J_t_m) = tan.rjacinv();
   }
 
   return tan;

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -296,13 +296,13 @@ SE3Base<_Derived>::log(OptJacobianRef J_t_m) const
   const SO3Tangent<Scalar> so3tan = asSO3().log();
 
   Tangent tan((typename Tangent::DataType() <<
-               so3tan.ljac().inverse()*translation(),
+               so3tan.ljacinv()*translation(),
                so3tan.coeffs()).finished());
 
   if (J_t_m)
   {
     // Jr^-1
-    (*J_t_m) = tan.rjac().inverse();
+    (*J_t_m) = tan.rjacinv();
   }
 
   return tan;

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -256,14 +256,14 @@ SE_2_3Base<_Derived>::log(OptJacobianRef J_t_m) const
   const SO3Tangent<Scalar> so3tan = asSO3().log();
 
   Tangent tan((typename Tangent::DataType() <<
-               so3tan.ljac().inverse()*translation(),
+               so3tan.ljacinv()*translation(),
                so3tan.coeffs(),
-               so3tan.ljac().inverse()*linearVelocity()).finished());
+               so3tan.ljacinv()*linearVelocity()).finished());
 
   if (J_t_m)
   {
     // Jr^-1
-    (*J_t_m) = tan.rjac().inverse();
+    (*J_t_m) = tan.rjacinv();
   }
 
   return tan;

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -194,8 +194,8 @@ SO3Base<_Derived>::log(OptJacobianRef J_t_m) const
      *            = atan(-sin(angle), -cos(angle))
      */
     const Scalar two_angle = Scalar(2.0) * ((cos_angle < Scalar(0.0)) ?
-                                 atan2(-sin_angle, -cos_angle) :
-                                 atan2( sin_angle,  cos_angle));
+                                 Scalar(atan2(-sin_angle, -cos_angle)) :
+                                 Scalar(atan2( sin_angle,  cos_angle)));
 
     log_coeff = two_angle / sin_angle;
   }


### PR DESCRIPTION
The ambiguous ternary type issue occurs when using a datatype that uses expression types to represent operations (in this case minus and arctan2), which is the case with many libraries for auto-differentiation.