### PR TITLE
Adding Ceres::Jet unit tests

### DIFF
--- a/include/manif/impl/rn/Rn_base.h
+++ b/include/manif/impl/rn/Rn_base.h
@@ -1,10 +1,8 @@
 #ifndef _MANIF_MANIF_RN_BASE_H_
 #define _MANIF_MANIF_RN_BASE_H_
 
-#include "manif/impl/so2/SO2_properties.h"
+#include "manif/impl/rn/Rn_properties.h"
 #include "manif/impl/lie_group_base.h"
-
-#include <iostream>
 
 namespace manif {
 

--- a/include/manif/impl/traits.h
+++ b/include/manif/impl/traits.h
@@ -48,6 +48,19 @@ struct traitscast<_Class<_Scalar>, _NewScalar>
   using cast = _Class<_NewScalar>;
 };
 
+/**
+ * @brief Specialization for Rn.
+ */
+template <
+  template <typename, unsigned int> class _Class,
+  typename _NewScalar,
+  typename _Scalar,
+  unsigned int _Dim>
+struct traitscast<_Class<_Scalar, _Dim>, _NewScalar>
+{
+  using cast = _Class<_NewScalar, _Dim>;
+};
+
 //! @brief A traits for detecting AutoDiff scalar types
 template <typename Scalar> struct is_ad : std::integral_constant<bool, false> { };
 

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Ceres tests
 
+manif_add_gtest(gtest_rn_ceres gtest_rn_ceres.cpp)
+
 manif_add_gtest(gtest_so2_ceres gtest_so2_ceres.cpp)
 
 manif_add_gtest(gtest_se2_autodiff gtest_se2_autodiff.cpp)
@@ -9,7 +11,12 @@ manif_add_gtest(gtest_so3_ceres gtest_so3_ceres.cpp)
 
 manif_add_gtest(gtest_se3_ceres gtest_se3_ceres.cpp)
 
+manif_add_gtest(gtest_se23_ceres gtest_se23_ceres.cpp)
+
 set(CXX_11_TEST_TARGETS_CERES
+  # Rn
+  gtest_rn_ceres
+
   # SO2
   gtest_so2_ceres
 
@@ -22,6 +29,9 @@ set(CXX_11_TEST_TARGETS_CERES
 
   # SE3
   gtest_se3_ceres
+
+  # SE23
+  gtest_se23_ceres
 )
 
 foreach(target ${CXX_11_TEST_TARGETS_CERES})

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -8,59 +8,71 @@
   using TEST_##manifold##_JACOBIANS_CERES_TESTER = JacobianCeresTester<manifold>;               \
   TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_INVERSE_JACOBIAN)    \
   { evalInverseJac(); }                                                                         \
+  TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_LOG_JACOBIAN)        \
+  { evalLogJac(); }                                                                             \
   TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_RMINUS_JACOBIANS)    \
   { evalRminusJacs(); }                                                                         \
   TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_LMINUS_JACOBIANS)    \
-  { evalLminusJacs(); }
+  { evalLminusJacs(); }                                                                         \
+  TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_COMPOSE_JACOBIANS)   \
+  { evalComposeJacs(); }                                                                        \
+  TEST_F(TEST_##manifold##_JACOBIANS_CERES_TESTER, TEST_##manifold##_CERES_BETWEEN_JACOBIANS)   \
+  { evalBetweenJacs(); }
+
+#define __MANIF_FUNCTOR_COMMON_TYPEDEF                                            \
+  using LieGroup = _LieGroup;                                                     \
+  using Tangent  = typename _LieGroup::Tangent;                                   \
+                                                                                  \
+  template <typename _Scalar>                                                     \
+  using LieGroupTemplate = typename LieGroup::template LieGroupTemplate<_Scalar>; \
+                                                                                  \
+  template <typename _Scalar>                                                     \
+  using TangentTemplate = typename Tangent::template TangentTemplate<_Scalar>;
 
 namespace manif {
 
-template <template <typename LieGroup> class Derived, typename LieGroup>
+template <
+  template <typename LieGroup> class Derived,
+  unsigned int O, unsigned int I, typename LieGroup
+>
 struct MakeUnaryCostFuncHelper
 {
+  using Jacobian = Eigen::Matrix<
+    typename LieGroup::Scalar, O, I, Eigen::RowMajor
+  >;
+
   static
-  std::shared_ptr<
-    ceres::AutoDiffCostFunction<
-      Derived<LieGroup>, LieGroup::RepSize, LieGroup::RepSize>>
+  std::shared_ptr<ceres::AutoDiffCostFunction<Derived<LieGroup>, O, I>>
   make_costfunc()
   {
-    return std::make_shared<
-        ceres::AutoDiffCostFunction<
-          Derived<LieGroup>,
-          LieGroup::RepSize,
-          LieGroup::RepSize>>(new Derived<LieGroup>());
+    return std::make_shared<ceres::AutoDiffCostFunction<Derived<LieGroup>, O, I>>(
+      new Derived<LieGroup>()
+    );
   }
 };
 
-template <template <typename LieGroup> class Derived, typename LieGroup>
+template <
+  template <typename _LieGroup> class _Derived,
+  unsigned int _O, unsigned int _I0, unsigned int _I1, typename _LieGroup
+>
 struct MakeBinaryCostFuncHelper
 {
   static
-  std::shared_ptr<
-    ceres::AutoDiffCostFunction<
-      Derived<LieGroup>, LieGroup::DoF, LieGroup::RepSize, LieGroup::RepSize>>
+  std::shared_ptr<ceres::AutoDiffCostFunction<_Derived<_LieGroup>, _O, _I0, _I1>>
   make_costfunc()
   {
-    return std::make_shared<
-        ceres::AutoDiffCostFunction<
-          Derived<LieGroup>,
-          LieGroup::DoF,
-          LieGroup::RepSize,
-          LieGroup::RepSize>>(new Derived<LieGroup>());
+    return std::make_shared<ceres::AutoDiffCostFunction<_Derived<_LieGroup>, _O, _I0, _I1>>(
+      new _Derived<_LieGroup>()
+    );
   }
 };
 
 template <typename _LieGroup>
-struct CeresRminusFunctor : MakeBinaryCostFuncHelper<CeresRminusFunctor, _LieGroup>
+struct CeresRminusFunctor : MakeBinaryCostFuncHelper<
+  CeresRminusFunctor, _LieGroup::DoF, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup
+>
 {
-  using LieGroup = _LieGroup;
-  using Tangent  = typename _LieGroup::Tangent;
-
-  template <typename _Scalar>
-  using LieGroupTemplate = typename LieGroup::template LieGroupTemplate<_Scalar>;
-
-  template <typename _Scalar>
-  using TangentTemplate = typename Tangent::template TangentTemplate<_Scalar>;
+  __MANIF_FUNCTOR_COMMON_TYPEDEF;
 
   using Jacobian =
     Eigen::Matrix<typename LieGroup::Scalar,
@@ -85,16 +97,11 @@ struct CeresRminusFunctor : MakeBinaryCostFuncHelper<CeresRminusFunctor, _LieGro
 };
 
 template <typename _LieGroup>
-struct CeresLminusFunctor : MakeBinaryCostFuncHelper<CeresLminusFunctor, _LieGroup>
+struct CeresLminusFunctor : MakeBinaryCostFuncHelper<
+  CeresLminusFunctor, _LieGroup::DoF, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup
+>
 {
-  using LieGroup = _LieGroup;
-  using Tangent  = typename _LieGroup::Tangent;
-
-  template <typename _Scalar>
-  using LieGroupTemplate = typename LieGroup::template LieGroupTemplate<_Scalar>;
-
-  template <typename _Scalar>
-  using TangentTemplate = typename Tangent::template TangentTemplate<_Scalar>;
+  __MANIF_FUNCTOR_COMMON_TYPEDEF;
 
   using Jacobian =
     Eigen::Matrix<typename LieGroup::Scalar,
@@ -119,16 +126,12 @@ struct CeresLminusFunctor : MakeBinaryCostFuncHelper<CeresLminusFunctor, _LieGro
 };
 
 template <typename _LieGroup>
-struct CeresInverseFunctor : MakeUnaryCostFuncHelper<CeresInverseFunctor, _LieGroup>
+struct CeresInverseFunctor : MakeUnaryCostFuncHelper<
+  CeresInverseFunctor, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup
+>
 {
   template <typename _Scalar>
   using LieGroupTemplate = typename _LieGroup::template LieGroupTemplate<_Scalar>;
-
-  using Jacobian =
-    Eigen::Matrix<typename _LieGroup::Scalar,
-                  _LieGroup::RepSize,
-                  _LieGroup::RepSize,
-                  Eigen::RowMajor>;
 
   template <typename T>
   bool operator()(const T* const state_raw,
@@ -144,22 +147,11 @@ struct CeresInverseFunctor : MakeUnaryCostFuncHelper<CeresInverseFunctor, _LieGr
 };
 
 template <typename _LieGroup>
-struct CeresLogFunctor
+struct CeresLogFunctor : MakeUnaryCostFuncHelper<
+  CeresLogFunctor, _LieGroup::DoF, _LieGroup::RepSize, _LieGroup
+>
 {
-  using LieGroup = _LieGroup;
-  using Tangent  = typename _LieGroup::Tangent;
-
-  template <typename _Scalar>
-  using LieGroupTemplate = typename LieGroup::template LieGroupTemplate<_Scalar>;
-
-  template <typename _Scalar>
-  using TangentTemplate = typename Tangent::template TangentTemplate<_Scalar>;
-
-  using Jacobian =
-    Eigen::Matrix<typename _LieGroup::Scalar,
-                  _LieGroup::DoF,
-                  _LieGroup::RepSize,
-                  Eigen::RowMajor>;
+  __MANIF_FUNCTOR_COMMON_TYPEDEF;
 
   template <typename T>
   bool operator()(const T* const state_raw,
@@ -172,18 +164,63 @@ struct CeresLogFunctor
 
     return true;
   }
+};
 
-  static
-  std::shared_ptr<
-    ceres::AutoDiffCostFunction<
-      CeresInverseFunctor<LieGroup>, LieGroup::DoF, LieGroup::RepSize>>
-  make_costfunc()
+template <typename _LieGroup>
+struct CeresComposeFunctor : MakeBinaryCostFuncHelper<
+  CeresComposeFunctor, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup
+>
+{
+  __MANIF_FUNCTOR_COMMON_TYPEDEF;
+
+  using Jacobian =
+    Eigen::Matrix<typename LieGroup::Scalar,
+                  LieGroup::RepSize,
+                  LieGroup::RepSize,
+                  Eigen::RowMajor>;
+
+  template <typename T>
+  bool operator()(const T* const lhs_raw,
+                  const T* const rhs_raw,
+                  T* residuals_raw) const
   {
-    return std::make_shared<
-        ceres::AutoDiffCostFunction<
-          CeresInverseFunctor<LieGroup>,
-          LieGroup::DoF,
-          LieGroup::RepSize>>(new CeresInverseFunctor<LieGroup>());
+    const Eigen::Map<const LieGroupTemplate<T>> lhs_state(lhs_raw);
+    const Eigen::Map<const LieGroupTemplate<T>> rhs_state(rhs_raw);
+
+    Eigen::Map<LieGroupTemplate<T>> residuals(residuals_raw);
+
+    residuals = lhs_state.compose(rhs_state);
+
+    return true;
+  }
+};
+
+template <typename _LieGroup>
+struct CeresBetweenFunctor : MakeBinaryCostFuncHelper<
+  CeresBetweenFunctor, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup::RepSize, _LieGroup
+>
+{
+  __MANIF_FUNCTOR_COMMON_TYPEDEF;
+
+  using Jacobian =
+    Eigen::Matrix<typename LieGroup::Scalar,
+                  LieGroup::RepSize,
+                  LieGroup::RepSize,
+                  Eigen::RowMajor>;
+
+  template <typename T>
+  bool operator()(const T* const lhs_raw,
+                  const T* const rhs_raw,
+                  T* residuals_raw) const
+  {
+    const Eigen::Map<const LieGroupTemplate<T>> lhs_state(lhs_raw);
+    const Eigen::Map<const LieGroupTemplate<T>> rhs_state(rhs_raw);
+
+    Eigen::Map<LieGroupTemplate<T>> residuals(residuals_raw);
+
+    residuals = lhs_state.between(rhs_state);
+
+    return true;
   }
 };
 
@@ -210,7 +247,9 @@ class JacobianCeresTester : public ::testing::Test
   using Inverse = CeresInverseFunctor<LieGroup>;
   using Rminus = CeresRminusFunctor<LieGroup>;
   using Lminus = CeresLminusFunctor<LieGroup>;
-  // using Log = CeresLogFunctor<LieGroup>;
+  using Log = CeresLogFunctor<LieGroup>;
+  using Compose = CeresComposeFunctor<LieGroup>;
+  using Between = CeresBetweenFunctor<LieGroup>;
 
   // void local_deparameterization_ComputeJacobian(
   //   double* state,
@@ -250,11 +289,13 @@ public:
 
     state = LieGroup::Random();
     state_other = LieGroup::Random();
+    state_out = LieGroup::Random();
 
     delta = Tangent::Random();
 
     state_raw = state.data();
     state_other_raw = state_other.data();
+    state_out_raw = state_out.data();
 
     delta_raw = delta.data();
   }
@@ -267,17 +308,11 @@ public:
     double*  ad_r_J_out_s_raw = ad_r_J_out_spd.data();
     jacobians = &ad_r_J_out_s_raw;
 
-    // Autodiff
-
-    Inverse::make_costfunc()->Evaluate(
-      parameters, state_other_raw, jacobians
-    );
+    Inverse::make_costfunc()->Evaluate(parameters, state_other_raw, jacobians);
 
     EXPECT_MANIF_NEAR(state.inverse(), state_other);
 
-    local_parameterization->ComputeJacobian(
-      state_raw, J_locpar.data()
-    );
+    local_parameterization->ComputeJacobian(state_raw, adJ_locpar.data());
 
     // Compute the local_de-parameterization (?) Jac
     parameters = new double*[2];
@@ -298,7 +333,7 @@ public:
     //   state_other_raw, adJ_locdepar.data()
     // );
 
-    adJ_out_s = adJ_locdepar * (ad_r_J_out_spd * J_locpar);
+    adJ_out_s = adJ_locdepar * (ad_r_J_out_spd * adJ_locpar);
 
     state.inverse(J_out_s);
 
@@ -306,6 +341,25 @@ public:
 
     delete[] parameters;
     delete[] jacobians;
+  }
+
+  void evalLogJac()
+  {
+    parameters = &state_raw;
+
+    typename Log::Jacobian ad_r_J_out_spd;
+    double*  ad_r_J_out_s_raw = ad_r_J_out_spd.data();
+    jacobians = &ad_r_J_out_s_raw;
+
+    Log::make_costfunc()->Evaluate(parameters, delta_raw, jacobians);
+
+    EXPECT_MANIF_NEAR(state.log(J_out_s), delta);
+
+    local_parameterization->ComputeJacobian(state_raw, adJ_locpar.data());
+
+    adJ_out_s = ad_r_J_out_spd * adJ_locpar;
+
+    EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s);
   }
 
   /**
@@ -369,8 +423,6 @@ public:
     jacobians[0] = adJ_out_R_raw;
     jacobians[1] = adJ_out_RO_raw;
 
-    // Autodiff
-
     Lminus::make_costfunc()->Evaluate(parameters, delta_raw, jacobians);
 
     EXPECT_MANIF_NEAR(state.lminus(state_other), delta);
@@ -396,9 +448,105 @@ public:
     delete[] jacobians;
   }
 
+  void evalComposeJacs()
+  {
+    parameters = new double*[2];
+    parameters[0] = state_raw;
+    parameters[1] = state_other_raw;
+
+    typename Compose::Jacobian adJ_out_R, adJ_out_RO;
+    double*  adJ_out_R_raw = adJ_out_R.data();
+    double*  adJ_out_RO_raw = adJ_out_RO.data();
+    jacobians = new double*[2];
+    jacobians[0] = adJ_out_R_raw;
+    jacobians[1] = adJ_out_RO_raw;
+
+    Compose::make_costfunc()->Evaluate(parameters, state_out_raw, jacobians);
+
+    EXPECT_MANIF_NEAR(state.compose(state_other, J_out_s, J_out_so), state_out);
+
+    local_parameterization->ComputeJacobian(
+      state_raw, lhs_adJ_locpar.data()
+    );
+
+    // Compute the local_de-parameterization (?) Jac
+    parameters[0] = state_out_raw;
+    parameters[1] = state_out_raw;
+
+    typename Rminus::Jacobian adJ_locdepar, adJ_unused;
+    jacobians[0] = adJ_locdepar.data();
+    jacobians[1] = adJ_unused.data();
+
+    Rminus::make_costfunc()->Evaluate(parameters, delta_raw, jacobians);
+    //
+
+    adJ_out_s = adJ_locdepar * adJ_out_R * lhs_adJ_locpar;
+
+    EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s);
+
+    local_parameterization->ComputeJacobian(
+      state_other_raw, rhs_adJ_locpar.data()
+    );
+
+    adJ_out_so = adJ_locdepar * adJ_out_RO * rhs_adJ_locpar;
+
+    EXPECT_EIGEN_NEAR(J_out_so, adJ_out_so);
+
+    delete[] parameters;
+    delete[] jacobians;
+  }
+
+  void evalBetweenJacs()
+  {
+    parameters = new double*[2];
+    parameters[0] = state_raw;
+    parameters[1] = state_other_raw;
+
+    typename Between::Jacobian adJ_out_R, adJ_out_RO;
+    double*  adJ_out_R_raw = adJ_out_R.data();
+    double*  adJ_out_RO_raw = adJ_out_RO.data();
+    jacobians = new double*[2];
+    jacobians[0] = adJ_out_R_raw;
+    jacobians[1] = adJ_out_RO_raw;
+
+    Between::make_costfunc()->Evaluate(parameters, state_out_raw, jacobians);
+
+    EXPECT_MANIF_NEAR(state.between(state_other, J_out_s, J_out_so), state_out);
+
+    local_parameterization->ComputeJacobian(
+      state_raw, lhs_adJ_locpar.data()
+    );
+
+    // Compute the local_de-parameterization (?) Jac
+    parameters[0] = state_out_raw;
+    parameters[1] = state_out_raw;
+
+    typename Rminus::Jacobian adJ_locdepar, adJ_unused;
+    jacobians[0] = adJ_locdepar.data();
+    jacobians[1] = adJ_unused.data();
+
+    Rminus::make_costfunc()->Evaluate(parameters, delta_raw, jacobians);
+    //
+
+    adJ_out_s = adJ_locdepar * adJ_out_R * lhs_adJ_locpar;
+
+    EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s);
+
+    local_parameterization->ComputeJacobian(
+      state_other_raw, rhs_adJ_locpar.data()
+    );
+
+    adJ_out_so = adJ_locdepar * adJ_out_RO * rhs_adJ_locpar;
+
+    EXPECT_EIGEN_NEAR(J_out_so, adJ_out_so);
+
+    delete[] parameters;
+    delete[] jacobians;
+  }
+
 protected:
 
-  double *state_raw, *state_other_raw;
+  double *state_raw, *state_other_raw, *state_out_raw;
   double **parameters;
 
   double *delta_raw;
@@ -409,15 +557,14 @@ protected:
   LocalParameterizationPtr local_parameterization =
     make_local_parameterization_autodiff<LieGroup>();
 
-  LieGroup state;
-  LieGroup state_other;
+  LieGroup state, state_other, state_out;
 
   Tangent  delta;
 
   Jacobian J_out_s, J_out_so,
            adJ_out_s, adJ_out_so;
 
-  LocalParamJacobian J_locpar, lhs_adJ_locpar, rhs_adJ_locpar;
+  LocalParamJacobian adJ_locpar, lhs_adJ_locpar, rhs_adJ_locpar;
 };
 
 } // namespace manif

--- a/test/ceres/gtest_rn_ceres.cpp
+++ b/test/ceres/gtest_rn_ceres.cpp
@@ -1,0 +1,18 @@
+#include "manif/Rn.h"
+#include "ceres_test_utils.h"
+
+#include <ceres/ceres.h>
+
+using namespace manif;
+
+MANIF_TEST_JACOBIANS_CERES(R1d);
+MANIF_TEST_JACOBIANS_CERES(R3d);
+MANIF_TEST_JACOBIANS_CERES(R5d);
+MANIF_TEST_JACOBIANS_CERES(R7d);
+MANIF_TEST_JACOBIANS_CERES(R9d);
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/ceres/gtest_se23_ceres.cpp
+++ b/test/ceres/gtest_se23_ceres.cpp
@@ -1,0 +1,14 @@
+#include "manif/SE_2_3.h"
+#include "ceres_test_utils.h"
+
+#include <ceres/ceres.h>
+
+using namespace manif;
+
+MANIF_TEST_JACOBIANS_CERES(SE_2_3d);
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Using `Ceres::Jet` (autodiff), compute the Jacobians below and compare them against `manif` analytic one.

All Jacobians in `manif` are tested:
- inverse
- rplus
- lplus
- rminus
- lminus
- log
- compose
- between
- act

Depends on #199 for the `act` test.