### PR TITLE
Add traits `is_ad`

### DIFF
--- a/include/manif/ceres/ceres.h
+++ b/include/manif/ceres/ceres.h
@@ -10,6 +10,10 @@
 namespace manif {
 namespace internal {
 struct YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS{};
+
+template <typename _Scalar, int _N>
+struct is_ad<ceres::Jet<_Scalar, _N>> : std::integral_constant<bool, true> { };
+
 } /* namespace internal */
 
 #ifdef _MANIF_MANIF_SO2_H_

--- a/include/manif/impl/eigen.h
+++ b/include/manif/impl/eigen.h
@@ -134,7 +134,7 @@ struct traitscast<Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxC
  *             | x  0 |
  */
 template <typename _Scalar>
-typename std::enable_if<std::is_arithmetic<_Scalar>::value,
+typename std::enable_if<std::is_arithmetic<_Scalar>::value || internal::is_ad<_Scalar>::value,
                         Eigen::Matrix<_Scalar, 2, 2>>::type
 skew(const _Scalar v)
 {

--- a/include/manif/impl/traits.h
+++ b/include/manif/impl/traits.h
@@ -48,6 +48,22 @@ struct traitscast<_Class<_Scalar>, _NewScalar>
   using cast = _Class<_NewScalar>;
 };
 
+/**
+ * @brief Specialization for Rn.
+ */
+template <
+  template <typename, unsigned int> class _Class,
+  typename _NewScalar,
+  typename _Scalar,
+  unsigned int _Dim>
+struct traitscast<_Class<_Scalar, _Dim>, _NewScalar>
+{
+  using cast = _Class<_NewScalar, _Dim>;
+};
+
+//! @brief A traits for detecting AutoDiff scalar types
+template <typename Scalar> struct is_ad : std::integral_constant<bool, false> { };
+
 //! @brief Has function 'rjacinv' traits
 template<class, typename T> struct has_rjacinv_impl : std::false_type {};
 template<typename T> struct

--- a/include/manif/impl/traits.h
+++ b/include/manif/impl/traits.h
@@ -48,19 +48,6 @@ struct traitscast<_Class<_Scalar>, _NewScalar>
   using cast = _Class<_NewScalar>;
 };
 
-/**
- * @brief Specialization for Rn.
- */
-template <
-  template <typename, unsigned int> class _Class,
-  typename _NewScalar,
-  typename _Scalar,
-  unsigned int _Dim>
-struct traitscast<_Class<_Scalar, _Dim>, _NewScalar>
-{
-  using cast = _Class<_NewScalar, _Dim>;
-};
-
 //! @brief A traits for detecting AutoDiff scalar types
 template <typename Scalar> struct is_ad : std::integral_constant<bool, false> { };
 


### PR DESCRIPTION
Add a traits to detect when `Scalar` is an autodiff (AD) type.
Specialize it for `ceres::Jet`.

Fixes #198.