### PR TITLE
Add GitHub Actions workflow for Visual Studio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,8 @@ jobs:
         shell: bash
         run: |
           vcpkg install eigen3:x64-windows
-          mkdir ${{runner.workspace}}/build
+          cd ${{runner.workspace}}
+          mkdir build
       - name: Display config
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,11 @@ jobs:
     strategy:
       matrix:
         combinations: [{
-          "os": "gcc",
-          "cmake_generator": "g++"
+          "os": "windows-2016",
+          "cmake_generator": "Visual Studio 15 2017"
          }, {
-          "os": "clang",
-          "cmake_generator": "clang++"
+          "os": "windows-2019",
+          "cmake_generator": "Visual Studio 16 2019"
         }]
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -G"${{ matrix.combinations.cmake_generator }}" -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
+        run: cmake $GITHUB_WORKSPACE -G"${{ matrix.combinations.cmake_generator }}" -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
       - name: Build
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,41 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: make test
 
+  build-win:
+    runs-on: ${{ matrix.combinations.os }}
+    strategy:
+      matrix:
+        combinations: [{
+          "os": "gcc",
+          "cmake_generator": "g++"
+         }, {
+          "os": "clang",
+          "cmake_generator": "clang++"
+        }]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup
+        shell: bash
+        run: |
+          vcpkg install eigen
+          mkdir ${{runner.workspace}}/build
+      - name: Display config
+        shell: bash
+        run: |
+          echo "OS:" && $RUNNER_OS && echo ""
+          echo "Eigen:" && vcpkg list
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -G"${{ matrix.combinations.cmake_generator }}" -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
+      - name: Build
+        working-directory: ${{runner.workspace}}/build
+        run: cmake --build . --config Release
+      - name: Test
+        working-directory: ${{runner.workspace}}/build
+        run: ctest . -C Release
+
   cppcheck:
     needs: [build-ubuntu]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup
-        shell: bash
         run: |
           vcpkg install eigen3:x64-windows
           cd ${{runner.workspace}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -G"${{ matrix.combinations.cmake_generator }}" -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
+        run: cmake $GITHUB_WORKSPACE -G"${{ matrix.combinations.cmake_generator }}" -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
       - name: Build
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup
         shell: bash
         run: |
-          vcpkg install eigen
+          vcpkg install eigen3:x64-windows
           mkdir ${{runner.workspace}}/build
       - name: Display config
         shell: bash


### PR DESCRIPTION
As discussed previously with @artivis, this PR adds support to build and test manif on GitHub Actions with Visual Studio 2017 and 2019. I tried to follow the existing style of the CI, let me know if you prefer for something to be done in a different way. Let me also know if you prefer that I squash my commits, or if you just want to Squash and Merge via GitHub UI, thanks! 