### PR TITLE
[manifpy] General improvements in SO3 and SE3 objects 

### DIFF
--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -134,6 +134,19 @@ public:
    * @brief Normalize the underlying quaternion.
    */
   void normalize();
+
+  /**
+   * @brief Set the rotational as a quaternion.
+   * @param quaternion a unitary quaternion
+   */
+  void quat(const QuaternionDataType& quaternion);
+
+  /**
+   * @brief Set the rotational as a quaternion.
+   * @param quaternion an Eigen::Vector representing a unitary quaternion
+   */
+  template <typename _EigenDerived>
+  void quat(const Eigen::MatrixBase<_EigenDerived>& quaternion);
 };
 
 template <typename _Derived>
@@ -354,6 +367,26 @@ template <typename _Derived>
 void SO3Base<_Derived>::normalize()
 {
   coeffs().normalize();
+}
+
+template <typename _Derived>
+void SO3Base<_Derived>::quat(const QuaternionDataType& quaternion)
+{
+  quat(quaternion.coeffs());
+}
+
+template <typename _Derived>
+template <typename _EigenDerived>
+void SO3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived>& quaternion)
+{
+  using std::abs;
+  assert_vector_dim(quaternion, 4);
+  MANIF_ASSERT(abs(quaternion.norm()-Scalar(1)) <
+               Constants<Scalar>::eps_s,
+               "The quaternion is not normalized !",
+               invalid_argument);
+
+  coeffs() = quaternion;
 }
 
 namespace internal {

--- a/python/bindings_se3.cpp
+++ b/python/bindings_se3.cpp
@@ -29,7 +29,15 @@ void wrap_SE3(py::module &m)
 
   SE3.def(py::init<const Scalar, const Scalar, const Scalar,
                    const Scalar, const Scalar, const Scalar>());
-  // SE3.def(py::init<const Translation&, const Quaternion&>());
+  SE3.def(py::init([](const SE3d::Translation& pos, const Eigen::Vector4d& quat) {
+                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+                           throw pybind11::value_error("The quaternion is not normalized!");
+                       }
+                       return manif::SE3d(pos, quat);
+                   }),
+      py::arg("position"),
+      py::arg("quaternion"));
+
   // SE3.def(py::init<const Translation&, const Eigen::AngleAxis<Scalar>&>());
   // SE3.def(py::init<const Translation&, const manif::SO3<Scalar>&>());
   // SE3.def(py::init<igen::Transform<Scalar, 3, Eigen::Isometry>&>());

--- a/python/bindings_se3.cpp
+++ b/python/bindings_se3.cpp
@@ -45,11 +45,20 @@ void wrap_SE3(py::module &m)
   SE3.def("transform", &SE3d::transform);
   // SE3.def("isometry", &SE3d::isometry);
   SE3.def("rotation", &SE3d::rotation);
-  // SE3.def("quat", &SE3d::quat);
-  SE3.def(
-    "translation",
-    static_cast<SE3d::Translation (SE3d::*)(void) const>(&SE3d::translation)
-  );
+  SE3.def_property(
+      "translation",
+      static_cast<SE3d::Translation (SE3d::*)(void) const>(&SE3d::translation),
+      static_cast<void (SE3d::*)(const SE3d::Translation&)>(&SE3d::translation));
+  SE3.def_property(
+      "quat",
+      [](const manif::SE3d& se3) -> Eigen::Vector4d { return se3.coeffs().segment<4>(3); },
+      [](manif::SE3d& se3, const Eigen::Vector4d& quaternion) {
+          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+              throw pybind11::value_error("The quaternion is not normalized!");
+          }
+          se3.quat(quaternion);
+      });
+
   SE3.def("x", &SE3d::x);
   SE3.def("y", &SE3d::y);
   SE3.def("z", &SE3d::z);

--- a/python/bindings_se3.cpp
+++ b/python/bindings_se3.cpp
@@ -29,7 +29,7 @@ void wrap_SE3(py::module &m)
 
   SE3.def(py::init<const Scalar, const Scalar, const Scalar,
                    const Scalar, const Scalar, const Scalar>());
-  SE3.def(py::init([](const SE3d::Translation& pos, const Eigen::Vector4d& quat) {
+  SE3.def(py::init([](const SE3d::Translation& pos, const Eigen::Matrix<Scalar, 4, 1>& quat) {
                        if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
                            throw pybind11::value_error("The quaternion is not normalized!");
                        }
@@ -45,19 +45,28 @@ void wrap_SE3(py::module &m)
   SE3.def("transform", &SE3d::transform);
   // SE3.def("isometry", &SE3d::isometry);
   SE3.def("rotation", &SE3d::rotation);
-  SE3.def_property(
+
+  SE3.def(
       "translation",
-      static_cast<SE3d::Translation (SE3d::*)(void) const>(&SE3d::translation),
-      static_cast<void (SE3d::*)(const SE3d::Translation&)>(&SE3d::translation));
-  SE3.def_property(
+      static_cast<SE3d::Translation (SE3d::*)(void) const>(&SE3d::translation));
+  SE3.def(
+      "translation",
+      static_cast<void (SE3d::*)(const SE3d::Translation&)>(&SE3d::translation),
+      py::arg("translation"));
+
+  SE3.def(
       "quat",
-      [](const manif::SE3d& se3) -> Eigen::Vector4d { return se3.coeffs().segment<4>(3); },
-      [](manif::SE3d& se3, const Eigen::Vector4d& quaternion) {
+      [](const manif::SE3d& se3) -> Eigen::Matrix<Scalar, 4, 1> { return se3.coeffs().segment<4>(3); });
+
+  SE3.def(
+      "quat",
+      [](manif::SE3d& se3, const Eigen::Matrix<Scalar, 4, 1>& quaternion) {
           if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
               throw pybind11::value_error("The quaternion is not normalized!");
           }
           se3.quat(quaternion);
-      });
+      },
+      py::arg("quaternion"));
 
   SE3.def("x", &SE3d::x);
   SE3.def("y", &SE3d::y);

--- a/python/bindings_so3.cpp
+++ b/python/bindings_so3.cpp
@@ -46,7 +46,20 @@ void wrap_SO3(py::module &m)
   SO3.def("y", &manif::SO3d::y);
   SO3.def("z", &manif::SO3d::z);
   SO3.def("w", &manif::SO3d::w);
-  // SO3.def("quat", &manif::SO3d::quat);
+  SO3.def(
+      "quat",
+      [](const manif::SO3d& so3) -> Eigen::Matrix<Scalar, 4, 1> { return so3.coeffs(); });
+
+  SO3.def(
+      "quat",
+      [](manif::SO3d& so3, const Eigen::Matrix<Scalar, 4, 1>& quaternion) {
+          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+              throw pybind11::value_error("The quaternion is not normalized!");
+          }
+          so3.quat(quaternion);
+      },
+      py::arg("quaternion"));
+
   SO3.def("normalize", &manif::SO3d::normalize);
 
   // tangent

--- a/python/bindings_so3.cpp
+++ b/python/bindings_so3.cpp
@@ -26,6 +26,15 @@ void wrap_SO3(py::module &m)
 
   SO3.def(py::init<const Scalar, const Scalar, const Scalar>());
   SO3.def(py::init<const Scalar, const Scalar, const Scalar, const Scalar>());
+  SO3.def(py::init([](const Eigen::Vector4d& quat) {
+                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+                           throw pybind11::value_error("The quaternion is not normalized!");
+                       }
+
+                       return manif::SO3d(quat);
+                   }),
+      py::arg("quaternion"));
+
   // SO3.def(py::init<const Quaternion&>());
   // SO3.def(py::init<const Eigen::AngleAxis<Scalar>&>());
 

--- a/python/bindings_so3.cpp
+++ b/python/bindings_so3.cpp
@@ -26,7 +26,7 @@ void wrap_SO3(py::module &m)
 
   SO3.def(py::init<const Scalar, const Scalar, const Scalar>());
   SO3.def(py::init<const Scalar, const Scalar, const Scalar, const Scalar>());
-  SO3.def(py::init([](const Eigen::Vector4d& quat) {
+  SO3.def(py::init([](const Eigen::Matrix<Scalar, 4, 1>& quat) {
                        if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
                            throw pybind11::value_error("The quaternion is not normalized!");
                        }

--- a/test/python/test_se3.py
+++ b/test/python/test_se3.py
@@ -15,7 +15,10 @@ def test_constructor():
     assert 1 == state.x()
     assert 2 == state.y()
     assert 3 == state.z()
-    assert ([0, 0, 0, 1] == state.quat).all()
+    assert ([0, 0, 0, 1] == state.quat()).all()
+
+    with pytest.raises(ValueError):
+        state = SE3(position=np.array([1,2,3]), quaternion=np.array([1, 0, 0, 1]))
 
     # state = SE3(np.array([1,2,3]), AngleAxis(0, UnitX()))
     # assert 0 == state.x()
@@ -34,14 +37,17 @@ def test_accessors():
     assert 0 == state.y()
     assert 0 == state.z()
 
-    assert (np.zeros([1,3]) == state.translation).all()
-    assert ([0, 0, 0, 1] == state.quat).all()
+    assert (np.zeros([1,3]) == state.translation()).all()
+    assert ([0, 0, 0, 1] == state.quat()).all()
 
-    state.translation = [1, 2, 3]
-    assert ([1, 2, 3] == state.translation).all()
+    state.translation([1, 2, 3])
+    assert ([1, 2, 3] == state.translation()).all()
 
-    state.quat = [0, 1, 0, 0]
-    assert ([0, 1, 0, 0] == state.quat).all()
+    state.quat([0, 1, 0, 0])
+    assert ([0, 1, 0, 0] == state.quat()).all()
+
+    with pytest.raises(ValueError):
+        state.quat([0, 1, 0, 1])
 
     delta = SE3Tangent.Zero()
 

--- a/test/python/test_se3.py
+++ b/test/python/test_se3.py
@@ -11,10 +11,11 @@ def test_constructor():
     assert 0 == state.z()
     # assert 1 == state.quat()
 
-    # state = SE3(np.array([1,2,3]), Quaternion(1,0,0,0))
-    # assert 0 == state.x()
-    # assert 0 == state.y()
-    # assert 0 == state.z()
+    state = SE3(position=np.array([1,2,3]), quaternion=np.array([0,0,0,1]))
+    assert 1 == state.x()
+    assert 2 == state.y()
+    assert 3 == state.z()
+    assert ([0, 0, 0, 1] == state.quat).all()
 
     # state = SE3(np.array([1,2,3]), AngleAxis(0, UnitX()))
     # assert 0 == state.x()
@@ -32,6 +33,15 @@ def test_accessors():
     assert 0 == state.x()
     assert 0 == state.y()
     assert 0 == state.z()
+
+    assert (np.zeros([1,3]) == state.translation).all()
+    assert ([0, 0, 0, 1] == state.quat).all()
+
+    state.translation = [1, 2, 3]
+    assert ([1, 2, 3] == state.translation).all()
+
+    state.quat = [0, 1, 0, 0]
+    assert ([0, 1, 0, 0] == state.quat).all()
 
     delta = SE3Tangent.Zero()
 

--- a/test/python/test_so3.py
+++ b/test/python/test_so3.py
@@ -22,11 +22,11 @@ def test_constructor():
     assert 0 == state.z()
     assert 1 == state.w()
 
-    # state = SO3(Quaternion(1, 0, 0, 0))
-    # assert 0 == state.x()
-    # assert 0 == state.y()
-    # assert 0 == state.z()
-    # assert 1 == state.w()
+    state = SO3(quaternion=np.array([0, 0, 0, 1]))
+    assert 0 == state.x()
+    assert 0 == state.y()
+    assert 0 == state.z()
+    assert 1 == state.w()
 
     # state = SO3(AngleAxis(0, UnitX()))
     # assert 0 == state.x()

--- a/test/python/test_so3.py
+++ b/test/python/test_so3.py
@@ -1,7 +1,7 @@
 from manifpy import SO3, SO3Tangent
 
 import numpy as np
-
+import pytest
 
 def test_constructor():
     state = SO3(0, 0, 0, 1)
@@ -28,6 +28,9 @@ def test_constructor():
     assert 0 == state.z()
     assert 1 == state.w()
 
+    with pytest.raises(ValueError):
+        state = SO3(quaternion=np.array([1, 0, 0, 1]))
+
     # state = SO3(AngleAxis(0, UnitX()))
     # assert 0 == state.x()
     # assert 0 == state.y()
@@ -47,6 +50,14 @@ def test_accessors():
     assert 0 == state.y()
     assert 0 == state.z()
     assert 1 == state.w()
+
+    assert ([0, 0, 0, 1] == state.quat()).all()
+
+    state.quat([0, 1, 0, 0])
+    assert ([0, 1, 0, 0] == state.quat()).all()
+
+    with pytest.raises(ValueError):
+        state.quat([0, 1, 0, 1])
 
     delta = SO3Tangent.Zero()
 

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -78,6 +78,22 @@ TEST(TEST_SO3, TEST_SO3_IDENTITY2)
   EXPECT_DOUBLE_EQ(1, so3.w());
 }
 
+TEST(TEST_SO3, TEST_SO3_SET_QUATERNION)
+{
+  SO3d::DataType values; values << 0,0,0,1;
+  SO3d so3(values);
+
+  Eigen::AngleAxis<double> axisAngle(0.23, Eigen::Vector3d::UnitZ());
+  Eigen::Quaterniond quat(axisAngle);
+
+  so3.quat(quat);
+
+  EXPECT_DOUBLE_EQ(quat.coeffs()(0), so3.coeffs()(0));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(1), so3.coeffs()(1));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(2), so3.coeffs()(2));
+  EXPECT_DOUBLE_EQ(quat.coeffs()(3), so3.coeffs()(3));
+}
+
 TEST(TEST_SO3, TEST_SO3TAN_ANGVEL)
 {
   SO3Tangentd so3tan(SO3Tangentd::DataType(1,2,3));


### PR DESCRIPTION
This PR fixes #210 and ~~#209~~

~~In details:~~
~~#209 is fixed by https://github.com/artivis/manif/commit/fdd136b182c7554c7f9344c98168c65ffffc1ce2 where the bindings are installed in a folder in `<CMAKE_INSTALL_PREFIX>/<PYTHON_INSTALL_DIR>/manifpy` 
where `PYTHON_INSTALL_DIR` is given by~~
```python
from distutils import sysconfig 
print(sysconfig.get_python_lib(1,0,prefix=''))
```
~~in ubuntu 20.04 the script returns `lib/python3/dist-packages`~~

#210 is fixed by https://github.com/artivis/manif/commit/759debb15ec0cf58aab01b5650104fe4e6b550e8 Here I also added an assert to check that the quaternion is unitary. Finally https://github.com/artivis/manif/commit/2a3342a38607afcb83077ea32dda4bd60b67046d and https://github.com/artivis/manif/commit/64567d6b1a98aa4b119c9b1a1e5ab9a6cfd17fc4 add some constructors in python that simplifies the creation of SE3 and SO3 objects

This is an example of usage. First of all, I updated the bash with the following lines
```sh
 export PYTHONPATH=${PYTHONPATH}:${MANIF_INSTALL_PREFIX}/lib/python3/dist-packages
```

Now it's possible to run the following python script everywhere in the system 

```python
import manifpy as manif                                                                      

so3 = manif.SO3(quaternion=[1, 0, 0, 0])
print(so3)

# so3 = manif.SO3(quaternion=[2, 0, 0, 0]) <---- This generates a python exeption                            

se3 = manif.SE3(position=[0,2,0], quaternion=[1, 0, 0, 0])
print(se3.translation)
print(se3.quat)

# se3.quat = [2, 0, 0, 0] <---- This generates a python exception
```