### PR TITLE
Install gtest helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,9 @@ write_basic_package_version_file(
 
 # Config
 install(
-  FILES       "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake"
-              "${generated_dir}/${PROJECT_NAME}Config.cmake"
+  FILES
+    "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake"
+    "${generated_dir}/${PROJECT_NAME}Config.cmake"
   DESTINATION "${config_install_dir}"
 )
 
@@ -163,6 +164,13 @@ install(
   DESTINATION include
 )
 
+# Test utils
+install(
+  FILES
+    "${PROJECT_SOURCE_DIR}/test/gtest_eigen_utils.h"
+    "${PROJECT_SOURCE_DIR}/test/gtest_manif_utils.h"
+  DESTINATION "include/${PROJECT_NAME}/gtest"
+)
 
 ##############
 ## Examples ##

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -1,7 +1,7 @@
 #ifndef _MANIF_MANIF_CERES_TEST_UTILS_H_
 #define _MANIF_MANIF_CERES_TEST_UTILS_H_
 
-#include "../test_utils.h"
+#include "../gtest_manif_utils.h"
 #include "manif/ceres/ceres.h"
 
 #define MANIF_TEST_JACOBIANS_CERES(manifold)                                                    \

--- a/test/ceres/gtest_se2_autodiff.cpp
+++ b/test/ceres/gtest_se2_autodiff.cpp
@@ -3,7 +3,7 @@
 #include "manif/SE2.h"
 
 #include "manif/impl/utils.h"
-#include "../test_utils.h"
+#include "../gtest_manif_utils.h"
 
 #include "manif/ceres/ceres.h"
 

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -1,7 +1,7 @@
 #ifndef _MANIF_MANIF_TEST_COMMON_TESTER_H_
 #define _MANIF_MANIF_TEST_COMMON_TESTER_H_
 
-#include "test_utils.h"
+#include "gtest_manif_utils.h"
 #include "test_func.h"
 #include "manif/algorithms/interpolation.h"
 #include "manif/algorithms/average.h"

--- a/test/gtest_eigen_utils.h
+++ b/test/gtest_eigen_utils.h
@@ -1,5 +1,5 @@
-#ifndef _MANIF_TEST_EIGEN_GTEST_H_
-#define _MANIF_TEST_EIGEN_GTEST_H_
+#ifndef _MANIF_MANIF_GTEST_GTEST_EIGEN_UTILS_H_
+#define _MANIF_MANIF_GTEST_GTEST_EIGEN_UTILS_H_
 
 #include <gtest/gtest.h>
 
@@ -295,4 +295,4 @@ EXPECT_TRUE(isEigenMatrixSameSize(Eigen::Vector2d::Zero(),
                                   Eigen::Vector4d::Zero()));
 */
 
-#endif /* _MANIF_TEST_EIGEN_GTEST_H_ */
+#endif /* _MANIF_MANIF_GTEST_GTEST_EIGEN_UTILS_H_ */

--- a/test/gtest_manif_utils.h
+++ b/test/gtest_manif_utils.h
@@ -1,10 +1,10 @@
-#ifndef _MANIF_MANIF_TEST_UTILS_H_
-#define _MANIF_MANIF_TEST_UTILS_H_
+#ifndef _MANIF_MANIF_GTEST_GTEST_MANIF_UTILS_H_
+#define _MANIF_MANIF_GTEST_GTEST_MANIF_UTILS_H_
 
 #include "manif/impl/lie_group_base.h"
 #include "manif/impl/utils.h"
 
-#include "eigen_gtest.h"
+#include "gtest_eigen_utils.h"
 
 #include <random>
 #include <chrono>
@@ -123,4 +123,4 @@ protected:
 
 } /* namespace manif */
 
-#endif /* _MANIF_MANIF_TEST_UTILS_H_ */
+#endif /* _MANIF_MANIF_GTEST_GTEST_MANIF_UTILS_H_ */


### PR DESCRIPTION
Rename & install gtest helpers (Eigen / manif).

It allows projects using `manif` to make use of the gtest helper macros such as `EXPECT_MANIF_NEAR( x, y )`.
They are not included by default with the global `manif.h` header file, one has to explicitly include them, e.g.

```cpp
#include <manif/gtest/gtest_manif_utils.h>
```