### PR TITLE
Run tests at/around identity

### DIFF
--- a/include/manif/algorithms/average.h
+++ b/include/manif/algorithms/average.h
@@ -53,7 +53,7 @@ template <template <typename LieGroup, typename...Args> class Container,
 LieGroup
 average_biinvariant(const Container<LieGroup, Args...>& points,
                     typename LieGroup::Scalar eps =
-                      Constants<typename LieGroup::Scalar>::eps_s,
+                      Constants<typename LieGroup::Scalar>::eps,
                     int max_iterations = 20)
 {
   using Scalar  = typename LieGroup::Scalar;
@@ -112,7 +112,7 @@ template <template <typename LieGroup, typename...Args> class Container,
 LieGroup
 average(const Container<LieGroup, Args...>& points,
         typename LieGroup::Scalar eps =
-          Constants<typename LieGroup::Scalar>::eps_s,
+          Constants<typename LieGroup::Scalar>::eps,
         int max_iterations = 20)
 {
   using Scalar  = typename LieGroup::Scalar;
@@ -150,7 +150,7 @@ average(const Container<LieGroup, Args...>& points,
     typename LieGroup::Jacobian G = ts.rjac().transpose() * ts.rjac();
     const Scalar n = ts.coeffs().transpose() * G * ts.coeffs();
 
-    if (n < Constants<Scalar>::eps_s)
+    if (n < Constants<Scalar>::eps)
       break;
 
     avg += ts;
@@ -168,7 +168,7 @@ template <template <typename LieGroup, typename...Args> class Container,
 LieGroup
 average_frechet_left(const Container<LieGroup, Args...>& points,
                      typename LieGroup::Scalar eps =
-                       Constants<typename LieGroup::Scalar>::eps_s,
+                       Constants<typename LieGroup::Scalar>::eps,
                      int max_iterations = 20)
 {
   using Scalar  = typename LieGroup::Scalar;
@@ -221,7 +221,7 @@ template <template <typename LieGroup, typename...Args> class Container,
 LieGroup
 average_frechet_right(const Container<LieGroup, Args...>& points,
                       typename LieGroup::Scalar eps =
-                        Constants<typename LieGroup::Scalar>::eps_s,
+                        Constants<typename LieGroup::Scalar>::eps,
                       int max_iterations = 20)
 {
   using Scalar  = typename LieGroup::Scalar;

--- a/include/manif/ceres/constants.h
+++ b/include/manif/ceres/constants.h
@@ -13,16 +13,11 @@ template <typename _Scalar, int N>
 struct Constants<ceres::Jet<_Scalar, N>>
 {
   static const ceres::Jet<_Scalar, N> eps;
-  static const ceres::Jet<_Scalar, N> eps_s;
 };
 
 template <typename _Scalar, int N>
 const ceres::Jet<_Scalar, N>
-Constants<ceres::Jet<_Scalar, N>>::eps = ceres::Jet<_Scalar, N>(1e-10);
-
-template <typename _Scalar, int N>
-const ceres::Jet<_Scalar, N>
-Constants<ceres::Jet<_Scalar, N>>::eps_s = ceres::Jet<_Scalar, N>(1e-15);
+Constants<ceres::Jet<_Scalar, N>>::eps = ceres::Jet<_Scalar, N>(1e-14);
 
 } /* namespace manif */
 

--- a/include/manif/constants.h
+++ b/include/manif/constants.h
@@ -47,8 +47,7 @@ T constexpr csqrt(T x)
 template <typename _Scalar>
 struct Constants
 {
-  static constexpr _Scalar eps      = _Scalar(1e-10);
-  static constexpr _Scalar eps_s    = _Scalar(1e-15); // ~
+  static constexpr _Scalar eps      = _Scalar(1e-14);
   static constexpr _Scalar eps_sqrt = internal::csqrt(eps);
 
   static constexpr _Scalar to_rad = _Scalar(MANIF_PI / 180.0);
@@ -57,8 +56,6 @@ struct Constants
 
 template <typename _Scalar>
 constexpr _Scalar Constants<_Scalar>::eps;
-template <typename _Scalar>
-constexpr _Scalar Constants<_Scalar>::eps_s;
 template <typename _Scalar>
 constexpr _Scalar Constants<_Scalar>::eps_sqrt;
 template <typename _Scalar>
@@ -69,8 +66,7 @@ constexpr _Scalar Constants<_Scalar>::to_deg;
 template <>
 struct Constants<float>
 {
-  static constexpr float eps      = float(1e-5);
-  static constexpr float eps_s    = float(1e-6); // ~
+  static constexpr float eps      = float(1e-6);
   static constexpr float eps_sqrt = internal::csqrt(eps);
 
   static constexpr float to_rad = float(MANIF_PI / 180.0);

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -121,7 +121,7 @@ SE2TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   Scalar A,  // sin_theta_by_theta
          B;  // one_minus_cos_theta_by_theta
 
-  if (theta_sq < Constants<Scalar>::eps_s)
+  if (theta_sq < Constants<Scalar>::eps)
   {
     // Taylor approximation
     A = Scalar(1) - Scalar(1. / 6.) * theta_sq;
@@ -143,7 +143,7 @@ SE2TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
     (*J_m_t)(1,0) = -B;
     (*J_m_t)(1,1) =  A;
 
-    if (theta_sq < Constants<Scalar>::eps_s)
+    if (theta_sq < Constants<Scalar>::eps)
     {
       (*J_m_t)(0,2) = -y() / Scalar(2) + theta * x() / Scalar(6);
       (*J_m_t)(1,2) =  x() / Scalar(2) + theta * y() / Scalar(6);
@@ -213,6 +213,9 @@ template <typename _Derived>
 typename SE2TangentBase<_Derived>::Jacobian
 SE2TangentBase<_Derived>::ljac() const
 {
+  using std::cos;
+  using std::sin;
+
   const Scalar theta = angle();
   const Scalar cos_theta = cos(theta);
   const Scalar sin_theta = sin(theta);
@@ -221,7 +224,7 @@ SE2TangentBase<_Derived>::ljac() const
   Scalar A,  // sin_theta_by_theta
          B;  // one_minus_cos_theta_by_theta
 
-  if (theta_sq < Constants<Scalar>::eps_s)
+  if (theta_sq < Constants<Scalar>::eps)
   {
     // Taylor approximation
     A = Scalar(1) - Scalar(1. / 6.) * theta_sq;
@@ -240,7 +243,7 @@ SE2TangentBase<_Derived>::ljac() const
   Jl(1,0) =  B;
   Jl(1,1) =  A;
 
-  if (theta_sq < Constants<Scalar>::eps_s)
+  if (theta_sq < Constants<Scalar>::eps)
   {
     Jl(0,2) =  y() / Scalar(2) + theta * x() / Scalar(6);
     Jl(1,2) = -x() / Scalar(2) + theta * y() / Scalar(6);

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -227,7 +227,7 @@ SE2Base<_Derived>::log(OptJacobianRef J_t_m) const
   Scalar A,  // sin_theta_by_theta
          B;  // one_minus_cos_theta_by_theta
 
-  if (abs(theta) < Constants<Scalar>::eps)
+  if (theta_sq < Constants<Scalar>::eps)
   {
     // Taylor approximation
     A = Scalar(1) - Scalar(1. / 6.) * theta_sq;
@@ -301,7 +301,7 @@ SE2Base<_Derived>::compose(
 
   const Scalar ret_sqnorm = ret_real*ret_real+ret_imag*ret_imag;
 
-  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps_s)
+  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps)
   {
     const Scalar scale = approxSqrtInv(ret_sqnorm);
     ret_real *= scale;
@@ -416,7 +416,7 @@ struct AssignmentEvaluatorImpl<SE2Base<Derived>>
     using std::abs;
     MANIF_ASSERT(
       abs(data.template tail<2>().norm()-typename SE2Base<Derived>::Scalar(1)) <
-      Constants<typename SE2Base<Derived>::Scalar>::eps_s,
+      Constants<typename SE2Base<Derived>::Scalar>::eps,
       "SE2 assigned data not normalized !",
       invalid_argument
     );

--- a/include/manif/impl/se3/SE3Tangent_base.h
+++ b/include/manif/impl/se3/SE3Tangent_base.h
@@ -256,7 +256,7 @@ void SE3TangentBase<_Derived>::fillQ(
     Scalar A(0.5), B, C, D;
 
     // Small angle approximation
-    if (theta_sq <= Constants<Scalar>::eps_s)
+    if (theta_sq <= Constants<Scalar>::eps)
     {
       B =  Scalar(1./6.)  + Scalar(1./120.)  * theta_sq;
       C = -Scalar(1./24.) + Scalar(1./720.)  * theta_sq;

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -252,7 +252,7 @@ void SE3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived>& quaternion)
   using std::abs;
   assert_vector_dim(quaternion, 4);
   MANIF_ASSERT(abs(quaternion.norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
+               Constants<Scalar>::eps,
                "The quaternion is not normalized !",
                invalid_argument);
 
@@ -452,7 +452,7 @@ struct AssignmentEvaluatorImpl<SE3Base<Derived>>
     using std::abs;
     MANIF_ASSERT(
       abs(data.template tail<4>().norm()-typename SE3Base<Derived>::Scalar(1)) <
-      Constants<typename SE3Base<Derived>::Scalar>::eps_s,
+      Constants<typename SE3Base<Derived>::Scalar>::eps,
       "SE3 assigned data not normalized !",
       manif::invalid_argument
     );

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -439,7 +439,7 @@ struct AssignmentEvaluatorImpl<SE_2_3Base<Derived>>
     using std::abs;
     MANIF_ASSERT(
       abs(data.template segment<4>(3).norm()-typename SE_2_3Base<Derived>::Scalar(1)) <
-      Constants<typename SE_2_3Base<Derived>::Scalar>::eps_s,
+      Constants<typename SE_2_3Base<Derived>::Scalar>::eps,
       "SE_2_3 assigned data not normalized !",
       manif::invalid_argument
     );

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -223,7 +223,7 @@ SO2Base<_Derived>::compose(
 
   const Scalar ret_sqnorm = ret_real*ret_real+ret_imag*ret_imag;
 
-  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps_s)
+  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps)
   {
     const Scalar scale = approxSqrtInv(ret_sqnorm);
     ret_real *= scale;
@@ -332,7 +332,7 @@ struct AssignmentEvaluatorImpl<SO2Base<Derived>>
     using std::abs;
     MANIF_ASSERT(
       abs(data.norm()-typename SO2Base<Derived>::Scalar(1)) <
-      Constants<typename SO2Base<Derived>::Scalar>::eps_s,
+      Constants<typename SO2Base<Derived>::Scalar>::eps,
       "SO2 assigned data not normalized !",
       invalid_argument
     );

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -126,7 +126,7 @@ SO3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   const Scalar theta_sq = theta_vec.squaredNorm();
   const Scalar theta    = sqrt(theta_sq);
 
-  if (theta_sq > Constants<Scalar>::eps_s)
+  if (theta_sq > Constants<Scalar>::eps)
   {
     if (J_m_t)
     {
@@ -180,7 +180,7 @@ SO3TangentBase<_Derived>::ljac() const
   const LieAlg W = hat();
 
   // Small angle approximation
-  if (theta_sq <= Constants<Scalar>::eps_s)
+  if (theta_sq <= Constants<Scalar>::eps)
     return Jacobian::Identity() - Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle
@@ -210,7 +210,7 @@ SO3TangentBase<_Derived>::ljacinv() const
 
   const LieAlg W = hat();
 
-  if (theta_sq <= Constants<Scalar>::eps_s)
+  if (theta_sq <= Constants<Scalar>::eps)
     return Jacobian::Identity() + Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -181,7 +181,7 @@ SO3TangentBase<_Derived>::ljac() const
 
   // Small angle approximation
   if (theta_sq <= Constants<Scalar>::eps)
-    return Jacobian::Identity() - Scalar(0.5) * W;
+    return Jacobian::Identity() + Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle
   Jacobian M1, M2;
@@ -211,7 +211,7 @@ SO3TangentBase<_Derived>::ljacinv() const
   const LieAlg W = hat();
 
   if (theta_sq <= Constants<Scalar>::eps)
-    return Jacobian::Identity() + Scalar(0.5) * W;
+    return Jacobian::Identity() - Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle
   Jacobian M;

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -287,7 +287,7 @@ SO3Base<_Derived>::compose(
 
   const Scalar ret_sqnorm = ret_q.squaredNorm();
 
-  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps_s)
+  if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps)
   {
     const Scalar scale = approxSqrtInv(ret_sqnorm);
     ret_q.coeffs() *= scale;
@@ -382,7 +382,7 @@ void SO3Base<_Derived>::quat(const Eigen::MatrixBase<_EigenDerived>& quaternion)
   using std::abs;
   assert_vector_dim(quaternion, 4);
   MANIF_ASSERT(abs(quaternion.norm()-Scalar(1)) <
-               Constants<Scalar>::eps_s,
+               Constants<Scalar>::eps,
                "The quaternion is not normalized !",
                invalid_argument);
 
@@ -415,7 +415,7 @@ struct AssignmentEvaluatorImpl<SO3Base<Derived>>
     using std::abs;
     MANIF_ASSERT(
       abs(data.norm()-typename SO3Base<Derived>::Scalar(1)) <
-      Constants<typename SO3Base<Derived>::Scalar>::eps_s,
+      Constants<typename SO3Base<Derived>::Scalar>::eps,
       "SO3 assigned data not normalized !",
       manif::invalid_argument
     );

--- a/python/bindings_se3.cpp
+++ b/python/bindings_se3.cpp
@@ -30,7 +30,7 @@ void wrap_SE3(py::module &m)
   SE3.def(py::init<const Scalar, const Scalar, const Scalar,
                    const Scalar, const Scalar, const Scalar>());
   SE3.def(py::init([](const SE3d::Translation& pos, const Eigen::Matrix<Scalar, 4, 1>& quat) {
-                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps) {
                            throw pybind11::value_error("The quaternion is not normalized!");
                        }
                        return manif::SE3d(pos, quat);
@@ -61,7 +61,7 @@ void wrap_SE3(py::module &m)
   SE3.def(
       "quat",
       [](manif::SE3d& se3, const Eigen::Matrix<Scalar, 4, 1>& quaternion) {
-          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps) {
               throw pybind11::value_error("The quaternion is not normalized!");
           }
           se3.quat(quaternion);

--- a/python/bindings_so3.cpp
+++ b/python/bindings_so3.cpp
@@ -27,7 +27,7 @@ void wrap_SO3(py::module &m)
   SO3.def(py::init<const Scalar, const Scalar, const Scalar>());
   SO3.def(py::init<const Scalar, const Scalar, const Scalar, const Scalar>());
   SO3.def(py::init([](const Eigen::Matrix<Scalar, 4, 1>& quat) {
-                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+                       if(abs(quat.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps) {
                            throw pybind11::value_error("The quaternion is not normalized!");
                        }
 
@@ -53,7 +53,7 @@ void wrap_SO3(py::module &m)
   SO3.def(
       "quat",
       [](manif::SO3d& so3, const Eigen::Matrix<Scalar, 4, 1>& quaternion) {
-          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps_s) {
+          if(abs(quaternion.norm() - Scalar(1)) >= manif::Constants<Scalar>::eps) {
               throw pybind11::value_error("The quaternion is not normalized!");
           }
           so3.quat(quaternion);

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -8,6 +8,29 @@
 
 #define MANIF_TEST(manifold)                                              \
   using TEST_##manifold##_TESTER = CommonTester<manifold>;                \
+  INSTANTIATE_TEST_CASE_P(                                                \
+    TEST_##manifold##_TESTS,                                              \
+    TEST_##manifold##_TESTER,                                             \
+    ::testing::Values(                                                    \
+      std::make_tuple(                                                    \
+        manifold::Identity(),                                             \
+        manifold::Identity(),                                             \
+        manifold::Tangent::Zero(),                                        \
+        manifold::Tangent::Zero()                                         \
+      ),                                                                  \
+      std::make_tuple(                                                    \
+        (manifold::Tangent::Random()*1e-8).exp(),                         \
+        (manifold::Tangent::Random()*1e-8).exp(),                         \
+        manifold::Tangent::Random()*1e-8,                                 \
+        manifold::Tangent::Random()*1e-8                                  \
+      ),                                                                  \
+      std::make_tuple(                                                    \
+        manifold::Random(),                                               \
+        manifold::Random(),                                               \
+        manifold::Tangent::Random(),                                      \
+        manifold::Tangent::Random()                                       \
+      )                                                                   \
+    ));                                                                   \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MISC)                \
   { evalMisc(); }                                                         \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_COPY_CONSTRUCTOR)    \
@@ -20,31 +43,31 @@
   { evalMoveAssignment(); }                                               \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_DATA_PTR_VALID)      \
   { evalDataPtrValid(); }                                                 \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_IS_RPLUS)       \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_IS_RPLUS)       \
   { evalPlusIsRplus(); }                                                  \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_OP_IS_RPLUS)    \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_OP_IS_RPLUS)    \
   { evalPlusOpIsRplus(); }                                                \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_IS_RMINUS)     \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_IS_RMINUS)     \
   { evalMinusIsRminus(); }                                                \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_OP_IS_RMINUS)  \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_OP_IS_RMINUS)  \
   { evalMinusOpIsRminus(); }                                              \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_EQ)             \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_EQ)             \
   { evalPlusEq(); }                                                       \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_OP)          \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_OP)          \
   { evalCompOp(); }                                                       \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_EQ_OP)       \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_EQ_OP)       \
   { evalCompEq(); }                                                       \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_LIFT_RETRACT)        \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_LIFT_RETRACT)        \
   { evalLiftRetr(); }                                                     \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_RETRACT_LIFT)        \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_RETRACT_LIFT)        \
   { evalRetrLift(); }                                                     \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_WITH_INV)    \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_COMPOSE_WITH_INV)    \
   { evalComposeWithInv(); }                                               \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_BETWEEN_SELF)        \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_BETWEEN_SELF)        \
   { evalBetweenSelf(); }                                                  \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_ZERO)           \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_PLUS_ZERO)           \
   { evalPlusZero(); }                                                     \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_SELF)          \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_MINUS_SELF)          \
   { evalMinusSelf(); }                                                    \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_RETRACT_ZERO)        \
   { evalRetrZero(); }                                                     \
@@ -57,62 +80,90 @@
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_INTERP)              \
   { evalInterp(); }                                                       \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_AVG_BIINVARIANT)     \
-  { evalAvgBiInvariant(); }                                               \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_IS_APPROX)           \
+  { /*evalAvgBiInvariant();*/ }                                               \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_IS_APPROX)           \
   { evalIsApprox(); }                                                     \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_UNARY_MINUS)         \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_UNARY_MINUS)         \
   { evalUnaryMinus(); }                                                   \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_TANGENT_OPERATORS)   \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_TANGENT_OPERATORS)   \
   { evalSomeTangentOperators(); }                                         \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_GENERATORS_HAT)      \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_TANGENT_OPERATORS2)  \
+  { evalSomeTangentOperators2(); }                                        \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_GENERATORS_HAT)      \
   { evalGeneratorsHat(); }                                                \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_STREAM_OP)           \
   { evalStreamOp(); }                                                     \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_INNER)               \
+  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_INNER_ZERO)          \
+  { evalInnerZero(); }                                                    \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_INNER)               \
   { evalInner(); }                                                        \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_NUMERICAL_STABILITY) \
   { evalNumericalStability(); }                                           \
-  TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_SMALL_ADJ)           \
+  TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_SMALL_ADJ)           \
   { evalSmallAdj(); }                                                     \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_IDENTITY_ACT_POINT)  \
   { evalIdentityActPoint(); }
 
-#define MANIF_TEST_JACOBIANS(manifold)                                            \
-  using TEST_##manifold##_JACOBIANS_TESTER = JacobianTester<manifold>;            \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_INVERSE_JACOBIANS) \
-  { evalInverseJac(); }                                                           \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_LIFT_JACOBIANS)    \
-  { evalLiftJac(); }                                                              \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_RETRACT_JACOBIANS) \
-  { evalRetractJac(); }                                                           \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_RPLUS_JACOBIANS)   \
-  { evalRplusJac(); }                                                             \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_LPLUS_JACOBIANS)   \
-  { evalLplusJac(); }                                                             \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_PLUS_JACOBIANS)    \
-  { evalPlusJac(); }                                                              \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_RMINUS_JACOBIANS)  \
-  { evalRminusJac(); }                                                            \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_LMINUS_JACOBIANS)  \
-  { evalLminusJac(); }                                                            \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_MINUS_JACOBIANS)   \
-  { evalMinusJac(); }                                                             \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_COMPOSE_JACOBIANS) \
-  { evalComposeJac(); }                                                           \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_BETWEEN_JACOBIANS) \
-  { evalBetweenJac(); }                                                           \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_ADJ)               \
-  { evalAdj(); }                                                                  \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_ADJ_JL_JR)         \
-  { evalAdjJlJr(); }                                                              \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_JLJLinv_JRJRinv)   \
-  { evalJrJrinvJlJlinv(); }                                                       \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_ACT_JACOBIANS)     \
-  { evalActJac(); }                                                               \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_PLUS_T_JACOBIANS)  \
-  { evalTanPlusTanJac(); }                                                        \
-  TEST_F(TEST_##manifold##_JACOBIANS_TESTER, TEST_##manifold##_MINUS_T_JACOBIANS) \
+#define MANIF_TEST_JACOBIANS(manifold)                                                                                    \
+  using manifold##JacobiansTester = JacobianTester<manifold>;                                                             \
+  INSTANTIATE_TEST_CASE_P(                                                                                                \
+    manifold##JacobiansTests,                                                                                             \
+    manifold##JacobiansTester,                                                                                            \
+    ::testing::Values(                                                                                                    \
+      std::make_tuple(                                                                                                    \
+        manifold::Identity(),                                                                                             \
+        manifold::Identity(),                                                                                             \
+        manifold::Tangent::Zero(),                                                                                        \
+        manifold::Tangent::Zero()                                                                                         \
+      ),                                                                                                                  \
+      std::make_tuple(                                                                                                    \
+        (manifold::Tangent::Random()*1e-8).exp(),                                                                         \
+        (manifold::Tangent::Random()*1e-8).exp(),                                                                         \
+        manifold::Tangent::Random()*1e-8,                                                                                 \
+        manifold::Tangent::Random()*1e-8                                                                                  \
+      ),                                                                                                                  \
+      std::make_tuple(                                                                                                    \
+        manifold::Random(),                                                                                               \
+        manifold::Random(),                                                                                               \
+        manifold::Tangent::Random(),                                                                                      \
+        manifold::Tangent::Random()                                                                                       \
+      )                                                                                                                   \
+    ));                                                                                                                   \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_INVERSE_JACOBIANS)                                                  \
+  { evalInverseJac(); }                                                                                                   \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_LIFT_JACOBIANS)                                                     \
+  { evalLiftJac(); }                                                                                                      \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_RETRACT_JACOBIANS)                                                  \
+  { evalRetractJac(); }                                                                                                   \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_RPLUS_JACOBIANS)                                                    \
+  { evalRplusJac(); }                                                                                                     \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_LPLUS_JACOBIANS)                                                    \
+  { evalLplusJac(); }                                                                                                     \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_PLUS_JACOBIANS)                                                     \
+  { evalPlusJac(); }                                                                                                      \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_RMINUS_JACOBIANS)                                                   \
+  { evalRminusJac(); }                                                                                                    \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_LMINUS_JACOBIANS)                                                   \
+  { evalLminusJac(); }                                                                                                    \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_MINUS_JACOBIANS)                                                    \
+  { evalMinusJac(); }                                                                                                     \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_COMPOSE_JACOBIANS)                                                  \
+  { evalComposeJac(); }                                                                                                   \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_BETWEEN_JACOBIANS)                                                  \
+  { evalBetweenJac(); }                                                                                                   \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_ADJ)                                                                \
+  { evalAdj(); }                                                                                                          \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_ADJ_JL_JR)                                                          \
+  { evalAdjJlJr(); }                                                                                                      \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_JLJLinv_JRJRinv)                                                    \
+  { evalJrJrinvJlJlinv(); }                                                                                               \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_ACT_JACOBIANS)                                                      \
+  { evalActJac(); }                                                                                                       \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_PLUS_T_JACOBIANS)                                                   \
+  { evalTanPlusTanJac(); }                                                                                                \
+  TEST_P(manifold##JacobiansTester, TEST_##manifold##_MINUS_T_JACOBIANS)                                                  \
   { evalTanMinusTanJac(); }
+
 
 #define MANIF_TEST_MAP(manifold)                                          \
   using TEST_##manifold##_MAP_TESTER = CommonMapTester<manifold>;         \
@@ -134,11 +185,33 @@ namespace manif {
  * @brief A helper class to test some common functionalities
  */
 template <typename _LieGroup>
-class CommonTester : public ::testing::Test
+class CommonTester
+  : public testing::TestWithParam<
+    std::tuple<
+      _LieGroup, _LieGroup, typename _LieGroup::Tangent, typename _LieGroup::Tangent
+    >
+  >
+// : public ::testing::Test
 {
   using LieGroup = _LieGroup;
   using Scalar   = typename LieGroup::Scalar;
   using Tangent  = typename LieGroup::Tangent;
+
+  const LieGroup& getState() const {
+    return std::get<0>(this->GetParam());
+  }
+
+  const LieGroup& getStateOther() const {
+    return std::get<1>(this->GetParam());
+  }
+
+  const Tangent& getDelta() const {
+    return std::get<2>(this->GetParam());
+  }
+
+  const Tangent& getDeltaOther() const {
+    return std::get<3>(this->GetParam());
+  }
 
 public:
 
@@ -238,94 +311,90 @@ public:
 
   void evalPlusIsRplus()
   {
-    EXPECT_MANIF_NEAR(state.rplus(delta),
-                      state.plus(delta), tol_);
+    EXPECT_MANIF_NEAR(getState().rplus(getDelta()),
+                      getState().plus(getDelta()), tol_);
   }
 
   void evalPlusOpIsRplus()
   {
-    EXPECT_MANIF_NEAR(state.rplus(delta),
-                      state + delta, tol_);
+    EXPECT_MANIF_NEAR(getState().rplus(getDelta()),
+                      getState() + getDelta(), tol_);
   }
 
   void evalMinusIsRminus()
   {
-    EXPECT_MANIF_NEAR(state.rminus(state_other),
-                      state.minus(state_other), tol_);
+    EXPECT_MANIF_NEAR(getState().rminus(getStateOther()),
+                      getState().minus(getStateOther()), tol_);
   }
 
   void evalMinusOpIsRminus()
   {
-    EXPECT_MANIF_NEAR(state.rminus(state_other),
-                      state - state_other, tol_);
+    EXPECT_MANIF_NEAR(getState().rminus(getStateOther()),
+                      getState() - getStateOther(), tol_);
   }
 
   void evalPlusEq()
   {
-    LieGroup ret = state;
-    ret += delta;
+    LieGroup ret = getState();
+    ret += getDelta();
 
-    EXPECT_MANIF_NEAR(state + delta, ret, tol_);
+    EXPECT_MANIF_NEAR(getState() + getDelta(), ret, tol_);
   }
 
   void evalCompOp()
   {
-    EXPECT_MANIF_NEAR(state.compose(state_other),
-                      state * state_other, tol_);
+    EXPECT_MANIF_NEAR(getState().compose(getStateOther()),
+                      getState() * getStateOther(), tol_);
   }
 
   void evalCompEq()
   {
-    LieGroup ret = state;
-    ret *= state_other;
+    LieGroup ret = getState();
+    ret *= getStateOther();
 
-    EXPECT_MANIF_NEAR(state * state_other, ret, tol_);
+    EXPECT_MANIF_NEAR(getState() * getStateOther(), ret, tol_);
   }
 
   void evalLiftRetr()
   {
-    EXPECT_MANIF_NEAR(state, state.log().exp(), tol_);
+    EXPECT_MANIF_NEAR(getState(), getState().log().exp(), tol_);
   }
 
   void evalRetrLift()
   {
-    EXPECT_MANIF_NEAR(delta, delta.exp().log(), tol_);
+    EXPECT_MANIF_NEAR(getDelta(), getDelta().exp().log(), tol_);
   }
 
   void evalComposeWithInv()
   {
     EXPECT_MANIF_NEAR(LieGroup::Identity(),
-                      state.compose(state.inverse()), tol_);
+                      getState().compose(getState().inverse()), tol_);
     EXPECT_MANIF_NEAR(LieGroup::Identity(),
-                      state * state.inverse(), tol_);
+                      getState() * getState().inverse(), tol_);
 
-    LieGroup tmp = state; tmp *= state.inverse();
+    LieGroup tmp = getState(); tmp *= getState().inverse();
     EXPECT_MANIF_NEAR(LieGroup::Identity(), tmp, tol_);
 
-    EXPECT_MANIF_NEAR(state, state * LieGroup::Identity(), tol_);
-    EXPECT_MANIF_NEAR(state, LieGroup::Identity() * state, tol_);
+    EXPECT_MANIF_NEAR(getState(), getState() * LieGroup::Identity(), tol_);
+    EXPECT_MANIF_NEAR(getState(), LieGroup::Identity() * getState(), tol_);
   }
 
   void evalBetweenSelf()
   {
     EXPECT_MANIF_NEAR(LieGroup::Identity(),
-                      state.between(state), tol_);
+                      getState().between(getState()), tol_);
   }
 
   void evalPlusZero()
   {
-    EXPECT_MANIF_NEAR(LieGroup::Identity(),
-                      LieGroup::Identity() + Tangent::Zero(), tol_);
-    EXPECT_MANIF_NEAR(state,
-                      state + Tangent::Zero(), tol_);
+    EXPECT_MANIF_NEAR(getState(),
+                      getState() + Tangent::Zero(), tol_);
   }
 
   void evalMinusSelf()
   {
     EXPECT_MANIF_NEAR(Tangent::Zero(),
-                      LieGroup::Identity() - LieGroup::Identity(), tol_);
-    EXPECT_MANIF_NEAR(Tangent::Zero(),
-                      state - state, tol_);
+                      getState() - getState(), tol_);
   }
 
   void evalRetrZero()
@@ -338,10 +407,6 @@ public:
   {
     EXPECT_MANIF_NEAR(Tangent::Zero(),
                       LieGroup::Identity().log(), tol_);
-
-    Tangent t; t.setZero();
-    LieGroup l; l.setIdentity();
-    EXPECT_MANIF_NEAR(t, l.log(), tol_);
   }
 
   void evalRandom()
@@ -440,106 +505,113 @@ public:
     // Group
 
     EXPECT_TRUE(LieGroup::Identity().isApprox(LieGroup::Identity(), tol_));
-    EXPECT_FALSE(state.isApprox(LieGroup::Identity(), tol_));
 
     EXPECT_TRUE(LieGroup::Identity() == LieGroup::Identity());
-    EXPECT_FALSE(state == LieGroup::Identity());
 
-    EXPECT_TRUE(state.isApprox(state, tol_));
-    EXPECT_FALSE(state.isApprox(state_other, tol_));
+    EXPECT_TRUE(getState().isApprox(getState(), tol_));
+    EXPECT_FALSE(getState().isApprox(LieGroup::Random(), tol_));
 
     // cppcheck-suppress duplicateExpression
-    EXPECT_TRUE(state == state);
-    EXPECT_FALSE(state == state_other);
+    EXPECT_TRUE(getState() == getState());
+    EXPECT_FALSE(getState() == LieGroup::Random());
 
     // Tangent
 
     EXPECT_TRUE(Tangent::Zero().isApprox(Tangent::Zero(), tol_));
-    EXPECT_FALSE(delta.isApprox(Tangent::Zero(), tol_));
 
     EXPECT_TRUE(Tangent::Zero() == Tangent::Zero());
-    EXPECT_FALSE(delta == Tangent::Zero());
 
-    EXPECT_TRUE(delta.isApprox(delta, tol_));
-    EXPECT_FALSE(delta.isApprox(delta+delta, tol_));
+    EXPECT_TRUE(getDelta().isApprox(getDelta(), tol_));
+    EXPECT_FALSE(getDelta().isApprox(Tangent::Random(), tol_));
 
     // cppcheck-suppress duplicateExpression
-    EXPECT_TRUE(delta == delta);
-    EXPECT_FALSE(delta == (delta+delta));
+    EXPECT_TRUE(getDelta() == getDelta());
+    EXPECT_FALSE(getDelta() == Tangent::Random());
   }
 
   void evalUnaryMinus()
   {
-    Tangent minus_delta = -delta;
-    typename Tangent::DataType delta_data = delta.coeffs();
+    Tangent minus_delta = -getDelta();
+    typename Tangent::DataType delta_data = getDelta().coeffs();
     typename Tangent::DataType minus_delta_data = minus_delta.coeffs();
     EXPECT_EIGEN_NEAR(-delta_data, minus_delta_data);
-    EXPECT_EIGEN_NEAR(-delta.coeffs(), minus_delta.coeffs());
+    EXPECT_EIGEN_NEAR(-getDelta().coeffs(), minus_delta.coeffs());
   }
 
   void evalSomeTangentOperators()
   {
-    typename Tangent::DataType delta_data(delta.coeffs());
+    typename Tangent::DataType delta_data(getDelta().coeffs());
 
     // t+t
-    EXPECT_EIGEN_NEAR(delta.plus(delta).coeffs(), delta_data+delta_data);
+    EXPECT_EIGEN_NEAR(getDelta().plus(getDelta()).coeffs(), delta_data+delta_data);
 
     // t-t
-    EXPECT_EIGEN_NEAR(delta.minus(delta).coeffs(), delta_data-delta_data);
+    EXPECT_EIGEN_NEAR(getDelta().minus(getDelta()).coeffs(), delta_data-delta_data);
 
     // t+t
-    EXPECT_EIGEN_NEAR((delta+delta).coeffs(), delta_data+delta_data);
+    EXPECT_EIGEN_NEAR((getDelta()+getDelta()).coeffs(), delta_data+delta_data);
 
     // t-t
-    EXPECT_EIGEN_NEAR((delta-delta).coeffs(), delta_data-delta_data);
-
-    // t+=t
-    EXPECT_EIGEN_NEAR((delta+=delta).coeffs(), delta_data+=delta_data);
-
-    // t-=t
-    EXPECT_EIGEN_NEAR((delta-=delta).coeffs(), delta_data-=delta_data);
+    EXPECT_EIGEN_NEAR((getDelta()-getDelta()).coeffs(), delta_data-delta_data);
 
     // t+v
-    EXPECT_EIGEN_NEAR((delta+delta_data).coeffs(), delta_data+delta_data);
+    EXPECT_EIGEN_NEAR((getDelta()+delta_data).coeffs(), delta_data+delta_data);
 
     // t-v
-    EXPECT_EIGEN_NEAR((delta-delta_data).coeffs(), delta_data-delta_data);
-
-    // t+=v
-    EXPECT_EIGEN_NEAR((delta+=delta_data).coeffs(), delta_data+=delta_data);
-
-    // t-=v
-    EXPECT_EIGEN_NEAR((delta-=delta_data).coeffs(), delta_data-=delta_data);
+    EXPECT_EIGEN_NEAR((getDelta()-delta_data).coeffs(), delta_data-delta_data);
 
     // v+t
-    EXPECT_EIGEN_NEAR(delta_data+delta, delta_data+delta_data);
+    EXPECT_EIGEN_NEAR(delta_data+getDelta(), delta_data+delta_data);
 
     // v-t
-    EXPECT_EIGEN_NEAR(delta_data-delta, delta_data-delta_data);
+    EXPECT_EIGEN_NEAR(delta_data-getDelta(), delta_data-delta_data);
 
     // ret type is Tangent
     EXPECT_EIGEN_NEAR(
-          (delta+delta+delta-delta+delta_data-delta_data+delta/2.+delta*3.).coeffs(),
-          delta_data+delta_data+delta_data-delta_data+delta_data-delta_data+delta_data/2.+delta_data*3.
-          );
+      (getDelta()+getDelta()+getDelta()-getDelta()+delta_data-delta_data+getDelta()/2.+getDelta()*3.).coeffs(),
+      delta_data+delta_data+delta_data-delta_data+delta_data-delta_data+delta_data/2.+delta_data*3.
+    );
 
     // ret type is Tangent::DataType
     EXPECT_EIGEN_NEAR(
-          delta_data+delta+delta-delta+delta_data-delta_data+delta/2.+delta*3.,
-          delta_data+delta_data+delta_data-delta_data+delta_data-delta_data+delta_data/2.+delta_data*3.
-          );
+      delta_data+getDelta()+getDelta()-getDelta()+delta_data-delta_data+getDelta()/2.+getDelta()*3.,
+      delta_data+delta_data+delta_data-delta_data+delta_data-delta_data+delta_data/2.+delta_data*3.
+    );
 
     Tangent w;
     w << delta_data;
 
     EXPECT_EIGEN_NEAR(delta_data, w.coeffs());
 
-    EXPECT_EIGEN_NEAR((delta*3.14).coeffs(), delta_data*3.14);
-    EXPECT_EIGEN_NEAR((3.14*delta).coeffs(), 3.14*delta_data);
-    EXPECT_EIGEN_NEAR((delta*=3.14).coeffs(), delta_data*=3.14);
+    EXPECT_EIGEN_NEAR((getDelta()*3.14).coeffs(), delta_data*3.14);
+    EXPECT_EIGEN_NEAR((3.14*getDelta()).coeffs(), 3.14*delta_data);
 
-    EXPECT_EIGEN_NEAR((delta/5.12).coeffs(), delta_data/5.12);
-    EXPECT_EIGEN_NEAR((delta/=5.12).coeffs(), delta_data/=5.12);
+    EXPECT_EIGEN_NEAR((getDelta()/5.12).coeffs(), delta_data/5.12);
+  }
+
+  void evalSomeTangentOperators2()
+  {
+    Tangent delta_copy = getDelta();
+    typename Tangent::DataType delta_data(delta_copy.coeffs());
+
+    // t+=t
+    EXPECT_EIGEN_NEAR((delta_copy+=delta_copy).coeffs(), delta_data+=delta_data);
+
+    // t-=t
+    EXPECT_EIGEN_NEAR((delta_copy-=delta_copy).coeffs(), delta_data-=delta_data);
+
+    // t+=v
+    EXPECT_EIGEN_NEAR((delta_copy+=delta_data).coeffs(), delta_data+=delta_data);
+
+    // t-=v
+    EXPECT_EIGEN_NEAR((delta_copy-=delta_data).coeffs(), delta_data-=delta_data);
+
+    Tangent w;
+    w << delta_data;
+
+    EXPECT_EIGEN_NEAR((delta_copy*=3.14).coeffs(), delta_data*=3.14);
+
+    EXPECT_EIGEN_NEAR((delta_copy/=5.12).coeffs(), delta_data/=5.12);
   }
 
   void evalGeneratorsHat()
@@ -552,18 +624,18 @@ public:
 
     for (int i=0; i<Tangent::DoF; ++i)
     {
-      sum_delta_hat += delta.coeffs()(i) * Tangent::Generator(i);
+      sum_delta_hat += getDelta().coeffs()(i) * Tangent::Generator(i);
     }
 
-    EXPECT_EIGEN_NEAR(delta.hat(), sum_delta_hat);
+    EXPECT_EIGEN_NEAR(getDelta().hat(), sum_delta_hat);
 
     sum_delta_hat.setZero();
     for (int i=0; i<Tangent::DoF; ++i)
     {
-      sum_delta_hat += delta.coeffs()(i) * delta.generator(i);
+      sum_delta_hat += getDelta().coeffs()(i) * getDelta().generator(i);
     }
 
-    EXPECT_EIGEN_NEAR(delta.hat(), sum_delta_hat);
+    EXPECT_EIGEN_NEAR(getDelta().hat(), sum_delta_hat);
   }
 
   void evalStreamOp()
@@ -583,16 +655,21 @@ public:
     }
   }
 
-  void evalInner()
+  void evalInnerZero()
   {
     EXPECT_DOUBLE_EQ(0., Tangent::Zero().weightedNorm());
     EXPECT_DOUBLE_EQ(0., Tangent::Zero().squaredWeightedNorm());
     EXPECT_DOUBLE_EQ(0., Tangent::Zero().inner(Tangent::Zero()));
+  }
 
-    Tangent delta_other = Tangent::Random();
-
-    EXPECT_DOUBLE_EQ(delta.squaredWeightedNorm(), delta.inner(delta));
-    EXPECT_DOUBLE_EQ(delta.inner(delta_other), delta_other.inner(delta));
+  void evalInner()
+  {
+    EXPECT_DOUBLE_EQ(
+      getDelta().squaredWeightedNorm(), getDelta().inner(getDelta())
+    );
+    EXPECT_DOUBLE_EQ(
+      getDelta().inner(getDeltaOther()), getDeltaOther().inner(getDelta())
+    );
   }
 
   void evalNumericalStability()
@@ -607,10 +684,10 @@ public:
 
   void evalSmallAdj()
   {
-    const Tangent delta_other = Tangent::Random();
-
-    EXPECT_EIGEN_NEAR((delta.smallAdj() * delta_other).hat(),
-                      delta.hat() * delta_other.hat() - delta_other.hat() * delta.hat());
+    EXPECT_EIGEN_NEAR(
+      (getDelta().smallAdj() * getDeltaOther()).hat(),
+      getDelta().hat() * getDeltaOther().hat() - getDeltaOther().hat() * getDelta().hat()
+    );
   }
 
   void evalIdentityActPoint()
@@ -657,12 +734,33 @@ protected:
  *
  */
 template <typename _LieGroup>
-class JacobianTester : public ::testing::Test
+class JacobianTester
+  : public testing::TestWithParam<
+    std::tuple<
+      _LieGroup, _LieGroup, typename _LieGroup::Tangent, typename _LieGroup::Tangent
+    >
+  >
 {
   using LieGroup = _LieGroup;
   using Scalar   = typename LieGroup::Scalar;
   using Tangent  = typename LieGroup::Tangent;
   using Jacobian = typename LieGroup::Jacobian;
+
+  const LieGroup& getState() const {
+    return std::get<0>(this->GetParam());
+  }
+
+  const LieGroup& getStateOther() const {
+    return std::get<1>(this->GetParam());
+  }
+
+  const Tangent& getDelta() const {
+    return std::get<2>(this->GetParam());
+  }
+
+  const Tangent& getDeltaOther() const {
+    return std::get<3>(this->GetParam());
+  }
 
 public:
 
@@ -674,16 +772,13 @@ public:
   void SetUp() override
   {
     std::srand((unsigned int) time(0));
-
-    state       = LieGroup::Random();
-    state_other = LieGroup::Random();
-
-    delta = Tangent::Random();
-    w     = Tangent(Tangent::DataType::Random()*w_order_);
+    w = Tangent(Tangent::DataType::Random()*w_order_);
   }
 
   void evalInverseJac()
   {
+    const LieGroup& state = getState();
+
     LieGroup state_out = state.inverse(J_out_lhs);
 
     LieGroup state_pert = (state+w).inverse();
@@ -694,6 +789,8 @@ public:
 
   void evalLiftJac()
   {
+    const LieGroup& state = getState();
+
     Tangent state_out = state.log(J_out_lhs);
 
     Tangent state_pert = (state+w).log();
@@ -704,26 +801,21 @@ public:
 
   void evalRetractJac()
   {
+    const Tangent& delta = getDelta();
+
     LieGroup state_out = delta.exp(J_out_lhs);
 
     LieGroup state_pert = (delta+w).exp();
     LieGroup state_lin  = state_out + (J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
-
-    ///////
-
-    delta.setZero();
-    state_out = delta.exp(J_out_lhs);
-
-    state_pert = (delta+w).exp();
-    state_lin  = state_out + (J_out_lhs*w);
-
-    EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalComposeJac()
   {
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
     LieGroup state_out = state.compose(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -743,6 +835,9 @@ public:
 
   void evalBetweenJac()
   {
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
     LieGroup state_out = state.between(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -762,6 +857,9 @@ public:
 
   void evalRplusJac()
   {
+    const LieGroup& state = getState();
+    const Tangent& delta = getDelta();
+
     LieGroup state_out = state.rplus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -781,6 +879,9 @@ public:
 
   void evalLplusJac()
   {
+    const LieGroup& state = getState();
+    const Tangent& delta = getDelta();
+
     LieGroup state_out = state.lplus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -800,6 +901,9 @@ public:
 
   void evalPlusJac()
   {
+    const LieGroup& state = getState();
+    const Tangent& delta = getDelta();
+
     LieGroup state_out = state.plus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -819,6 +923,9 @@ public:
 
   void evalRminusJac()
   {
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
     Tangent state_out = state.rminus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -838,6 +945,9 @@ public:
 
   void evalLminusJac()
   {
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
     Tangent state_out = state.lminus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -857,6 +967,9 @@ public:
 
   void evalMinusJac()
   {
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
     Tangent state_out = state.minus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
@@ -876,7 +989,12 @@ public:
 
   void evalAdj()
   {
-    typename LieGroup::Jacobian Adja, Adjb, Adjc;
+    const LieGroup& state = getState();
+    const LieGroup& state_other = getStateOther();
+
+    const Tangent& delta = getDelta();
+
+    Jacobian Adja, Adjb, Adjc;
 
     Adja = state.adj();
     Adjb = state_other.adj();
@@ -891,7 +1009,9 @@ public:
 
   void evalAdjJlJr()
   {
-    typename LieGroup::Jacobian Adj, Jr, Jl;
+    const LieGroup& state = getState();
+
+    Jacobian Adj, Jr, Jl;
 
     Adj = state.adj();
 
@@ -906,29 +1026,13 @@ public:
     // Jr(-tau) = Jl(tau)
 
     EXPECT_EIGEN_NEAR(Jl, (-tan).rjac());
-
-    /////
-
-    state.setIdentity();
-
-    Adj = state.adj();
-    tan = state.log();
-
-    Jr = tan.rjac();
-    Jl = tan.ljac();
-
-    EXPECT_EIGEN_NEAR(Jl, Adj*Jr);
-    EXPECT_EIGEN_NEAR(Adj, Jl*Jr.inverse());
-
-    // Jr(-tau) = Jl(tau)
-
-    EXPECT_EIGEN_NEAR(Jl, (-tan).rjac());
   }
 
   void evalJrJrinvJlJlinv()
   {
-    using Jac = typename LieGroup::Jacobian;
-    Jac Jr, Jrinv, Jl, Jlinv;
+    Jacobian Jr, Jrinv, Jl, Jlinv;
+
+    const LieGroup& state = getState();
 
     const Tangent tan = state.log();
 
@@ -938,17 +1042,20 @@ public:
     Jrinv = tan.rjacinv();
     Jlinv = tan.ljacinv();
 
-    EXPECT_EIGEN_NEAR(Jac::Identity(), Jr*Jrinv);
-    EXPECT_EIGEN_NEAR(Jac::Identity(), Jl*Jlinv);
+    EXPECT_EIGEN_NEAR(Jacobian::Identity(), Jr*Jrinv);
+    EXPECT_EIGEN_NEAR(Jacobian::Identity(), Jl*Jlinv);
   }
 
   void evalActJac()
   {
-    using Point = Eigen::Matrix<typename LieGroup::Scalar, LieGroup::Dim, 1>;
+    using Scalar = typename LieGroup::Scalar;
+    using Point = Eigen::Matrix<Scalar, LieGroup::Dim, 1>;
     Point point = Point::Random();
 
-    Eigen::Matrix<typename LieGroup::Scalar, LieGroup::Dim, LieGroup::DoF> J_pout_s;
-    Eigen::Matrix<typename LieGroup::Scalar, LieGroup::Dim, LieGroup::Dim> J_pout_p;
+    Eigen::Matrix<Scalar, LieGroup::Dim, LieGroup::DoF> J_pout_s;
+    Eigen::Matrix<Scalar, LieGroup::Dim, LieGroup::Dim> J_pout_p;
+
+    const LieGroup& state = getState();
 
     const Point pointout = state.act(point, J_pout_s, J_pout_p);
 
@@ -959,7 +1066,8 @@ public:
     Point point_pert = (state+w).act(point);
     Point point_lin  = pointout + (J_pout_s*w.coeffs());
 
-    EXPECT_EIGEN_NEAR(point_pert, point_lin, tol_);
+    Scalar tol = (std::is_same<Scalar, float>::value)? 5e-4 : 1e-6;
+    EXPECT_EIGEN_NEAR(point_pert, point_lin, tol);
 
     // Jac wrt second element
 
@@ -971,7 +1079,8 @@ public:
 
   void evalTanPlusTanJac()
   {
-    const Tangent delta_other = Tangent::Random();
+    const Tangent& delta = getDelta();
+    const Tangent& delta_other = getDeltaOther();
 
     const Tangent delta_out = delta.plus(delta_other, J_out_lhs, J_out_rhs);
 
@@ -992,7 +1101,8 @@ public:
 
   void evalTanMinusTanJac()
   {
-    const Tangent delta_other = Tangent::Random();
+    const Tangent& delta = getDelta();
+    const Tangent& delta_other = getDeltaOther();
 
     const Tangent delta_out = delta.minus(delta_other, J_out_lhs, J_out_rhs);
 
@@ -1019,15 +1129,11 @@ public:
 
 protected:
 
-  double w_order_ = 1e-4;
-
   // relax tolerance for float type
-  Scalar tol_ = (std::is_same<Scalar, float>::value)? 1e-4 : 1e-7;
+  Scalar w_order_ = (std::is_same<Scalar, float>::value)? 1e-2 : 1e-4;
+  Scalar tol_ = (std::is_same<Scalar, float>::value)? 1e-4 : 1e-8;
 
-  LieGroup state;
-  LieGroup state_other;
-  Tangent  delta;
-  Tangent  w;
+  Tangent w;
 
   Jacobian J_out_lhs, J_out_rhs;
 };

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -662,6 +662,7 @@ class JacobianTester : public ::testing::Test
   using LieGroup = _LieGroup;
   using Scalar   = typename LieGroup::Scalar;
   using Tangent  = typename LieGroup::Tangent;
+  using Jacobian = typename LieGroup::Jacobian;
 
 public:
 
@@ -683,203 +684,192 @@ public:
 
   void evalInverseJac()
   {
-    typename LieGroup::Jacobian J_sout_s;
-    LieGroup state_out = state.inverse(J_sout_s);
+    LieGroup state_out = state.inverse(J_out_lhs);
 
     LieGroup state_pert = (state+w).inverse();
-    LieGroup state_lin  = state_out.rplus(J_sout_s*w);
+    LieGroup state_lin  = state_out.rplus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalLiftJac()
   {
-    typename LieGroup::Jacobian J_sout_s;
-    Tangent state_out = state.log(J_sout_s);
+    Tangent state_out = state.log(J_out_lhs);
 
     Tangent state_pert = (state+w).log();
-    Tangent state_lin  = state_out + (J_sout_s*w);
+    Tangent state_lin  = state_out + (J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalRetractJac()
   {
-    typename LieGroup::Jacobian J_sout_s;
-    LieGroup state_out = delta.exp(J_sout_s);
+    LieGroup state_out = delta.exp(J_out_lhs);
 
     LieGroup state_pert = (delta+w).exp();
-    LieGroup state_lin  = state_out + (J_sout_s*w);
+    LieGroup state_lin  = state_out + (J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     ///////
 
     delta.setZero();
-    state_out = delta.exp(J_sout_s);
+    state_out = delta.exp(J_out_lhs);
 
     state_pert = (delta+w).exp();
-    state_lin  = state_out + (J_sout_s*w);
+    state_lin  = state_out + (J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalComposeJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_sout_so;
-    LieGroup state_out = state.compose(state_other, J_sout_s, J_sout_so);
+    LieGroup state_out = state.compose(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     LieGroup state_pert = (state+w).compose(state_other);
-    LieGroup state_lin  = state_out + J_sout_s*w;
+    LieGroup state_lin  = state_out + J_out_lhs*w;
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.compose(state_other+w);
-    state_lin  = state_out + J_sout_so*w;
+    state_lin  = state_out + J_out_rhs*w;
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalBetweenJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_sout_so;
-    LieGroup state_out = state.between(state_other, J_sout_s, J_sout_so);
+    LieGroup state_out = state.between(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     LieGroup state_pert = (state + w).between(state_other);
-    LieGroup state_lin  = state_out + (J_sout_s * w);
+    LieGroup state_lin  = state_out + (J_out_lhs * w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.between(state_other + w);
-    state_lin  = state_out + (J_sout_so * w);
+    state_lin  = state_out + (J_out_rhs * w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalRplusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_sout_t;
-    LieGroup state_out = state.rplus(delta, J_sout_s, J_sout_t);
+    LieGroup state_out = state.rplus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     LieGroup state_pert = (state+w).rplus(delta);
-    LieGroup state_lin  = state_out.rplus(J_sout_s*w);
+    LieGroup state_lin  = state_out.rplus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.rplus(delta+w);
-    state_lin  = state_out.rplus(J_sout_t*w);
+    state_lin  = state_out.rplus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalLplusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_sout_t;
-    LieGroup state_out = state.lplus(delta, J_sout_s, J_sout_t);
+    LieGroup state_out = state.lplus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     LieGroup state_pert = (state+w).lplus(delta);
-    LieGroup state_lin  = state_out.rplus(J_sout_s*w);
+    LieGroup state_lin  = state_out.rplus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.lplus(delta+w);
-    state_lin  = state_out.rplus(J_sout_t*w);
+    state_lin  = state_out.rplus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalPlusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_mout_t;
-    LieGroup state_out = state.plus(delta, J_sout_s, J_mout_t);
+    LieGroup state_out = state.plus(delta, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     LieGroup state_pert = (state+w).plus(delta);
-    LieGroup state_lin  = state_out.rplus(J_sout_s*w);
+    LieGroup state_lin  = state_out.rplus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.plus(delta+w);
-    state_lin  = state_out.rplus(J_mout_t*w);
+    state_lin  = state_out.rplus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalRminusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_mout_so;
-    Tangent state_out = state.rminus(state_other, J_sout_s, J_mout_so);
+    Tangent state_out = state.rminus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     Tangent state_pert = (state+w).rminus(state_other);
-    Tangent state_lin  = state_out.plus(J_sout_s*w);
+    Tangent state_lin  = state_out.plus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.rminus(state_other+w);
-    state_lin  = state_out.plus(J_mout_so*w);
+    state_lin  = state_out.plus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalLminusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_mout_so;
-    Tangent state_out = state.lminus(state_other, J_sout_s, J_mout_so);
+    Tangent state_out = state.lminus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     Tangent state_pert = (state+w).lminus(state_other);
-    Tangent state_lin  = state_out.plus(J_sout_s*w);
+    Tangent state_lin  = state_out.plus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.lminus(state_other+w);
-    state_lin  = state_out.plus(J_mout_so*w);
+    state_lin  = state_out.plus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
 
   void evalMinusJac()
   {
-    typename LieGroup::Jacobian J_sout_s, J_mout_so;
-    Tangent state_out = state.minus(state_other, J_sout_s, J_mout_so);
+    Tangent state_out = state.minus(state_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     Tangent state_pert = (state+w).minus(state_other);
-    Tangent state_lin  = state_out.plus(J_sout_s*w);
+    Tangent state_lin  = state_out.plus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
 
     // Jac wrt second element
 
     state_pert = state.minus(state_other+w);
-    state_lin  = state_out.plus(J_mout_so*w);
+    state_lin  = state_out.plus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(state_pert, state_lin, tol_);
   }
@@ -981,46 +971,42 @@ public:
 
   void evalTanPlusTanJac()
   {
-    typename LieGroup::Jacobian J_tout_t0, J_tout_t1;
-
     const Tangent delta_other = Tangent::Random();
 
-    const Tangent delta_out = delta.plus(delta_other, J_tout_t0, J_tout_t1);
+    const Tangent delta_out = delta.plus(delta_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     Tangent delta_pert = (delta+w).plus(delta_other);
-    Tangent delta_lin  = delta_out.plus(J_tout_t0*w);
+    Tangent delta_lin  = delta_out.plus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(delta_pert, delta_lin, tol_);
 
     // Jac wrt second element
 
     delta_pert = delta.plus(delta_other+w);
-    delta_lin  = delta_out.plus(J_tout_t1*w);
+    delta_lin  = delta_out.plus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(delta_pert, delta_lin, tol_);
   }
 
   void evalTanMinusTanJac()
   {
-    typename LieGroup::Jacobian J_tout_t0, J_tout_t1;
-
     const Tangent delta_other = Tangent::Random();
 
-    const Tangent delta_out = delta.minus(delta_other, J_tout_t0, J_tout_t1);
+    const Tangent delta_out = delta.minus(delta_other, J_out_lhs, J_out_rhs);
 
     // Jac wrt first element
 
     Tangent delta_pert = (delta+w).minus(delta_other);
-    Tangent delta_lin  = delta_out.plus(J_tout_t0*w);
+    Tangent delta_lin  = delta_out.plus(J_out_lhs*w);
 
     EXPECT_MANIF_NEAR(delta_pert, delta_lin, tol_);
 
     // Jac wrt second element
 
     delta_pert = delta.minus(delta_other+w);
-    delta_lin  = delta_out.plus(J_tout_t1*w);
+    delta_lin  = delta_out.plus(J_out_rhs*w);
 
     EXPECT_MANIF_NEAR(delta_pert, delta_lin, tol_);
   }
@@ -1041,7 +1027,9 @@ protected:
   LieGroup state;
   LieGroup state_other;
   Tangent  delta;
-  Tangent  w; //
+  Tangent  w;
+
+  Jacobian J_out_lhs, J_out_rhs;
 };
 
 template <typename _LieGroup>


### PR DESCRIPTION
The test suit is currently run on values set and random (`LieGroup::Random()`). This PR extend the test suit to also run the tests at identity (`LieGroup::Identity()`) and very close to it (`(Tangent::Random()*1e-8).exp()`) in order to properly test the small angles approximations paths. Doing so made the issue in #223 clearly appear. While at it, the SO3 left-Jac small angle approx was wrong too...

Closes #223 