### PR TITLE
Add benchmarking & some opti

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        build_type: [Release, Debug]
         compiler: [{
           "cc": "gcc",
           "cxx": "g++"
@@ -45,7 +46,7 @@ jobs:
           echo "Eigen:" && apt-cache policy libeigen3-dev | grep Installed
       - name: Configure
         working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON
+        run: cmake $GITHUB_WORKSPACE -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
       - name: Build
         working-directory: ${{runner.workspace}}/build
         run: make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 option(BUILD_TESTING "Build all tests." OFF)
 option(ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(BUILD_EXAMPLES "Build all examples." OFF)
+option(BUILD_BENCHMARKING "Build all benchmarks." OFF)
 option(BUILD_PYTHON_BINDINGS "Build Python bindings with pybind11." OFF)
 option(BUILD_TESTING_PYTHON "Build Python tests only." OFF)
 
@@ -291,3 +292,13 @@ if(BUILD_PYTHON_BINDINGS AND (BUILD_TESTING OR BUILD_TESTING_PYTHON))
   add_subdirectory(test/python)
 
 endif()
+
+# ------------------------------------------------------------------------------
+# Benchmark
+# ------------------------------------------------------------------------------
+
+if(BUILD_BENCHMARKING)
+
+  add_subdirectory(benchmark)
+
+endif(BUILD_BENCHMARKING)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,65 @@
+find_package(benchmark QUIET)
+
+if(NOT benchmark_FOUND)
+  # If not found, download it
+  include(FetchContent)
+  FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.5.2
+  )
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  FetchContent_MakeAvailable(googlebenchmark)
+endif()
+
+# small helper function
+function(manif_add_benchmark target)
+  add_executable(${target} ${ARGN})
+  # add_dependencies(${target} gtest)
+  target_link_libraries(${target} ${PROJECT_NAME} benchmark::benchmark)
+
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # GCC is not strict enough by default, so enable most of the warnings.
+    target_compile_options(${target} PRIVATE
+      -Werror=all
+      -Werror=extra
+      -Wno-unknown-pragmas
+      -Wno-sign-compare
+      -Wno-unused-parameter
+      -Wno-missing-field-initializers
+      # When the library is built using GCC it is necessary to link
+      # with the pthread library due to how GCC implements std::thread.
+      # See https://github.com/google/benchmark#platform-specific-build-instructions
+      -pthread
+    )
+  endif()
+endfunction()
+
+manif_add_benchmark(benchmark_so2 benchmark_so2.cpp)
+manif_add_benchmark(benchmark_se2 benchmark_se2.cpp)
+manif_add_benchmark(benchmark_so3 benchmark_so3.cpp)
+manif_add_benchmark(benchmark_se3 benchmark_se3.cpp)
+manif_add_benchmark(benchmark_se_2_3 benchmark_se_2_3.cpp)
+manif_add_benchmark(benchmark_rn benchmark_rn.cpp)
+
+manif_add_benchmark(benchmark_manif benchmark_manif.cpp)
+
+manif_add_benchmark(benchmark_quat benchmark_quat.cpp)
+
+set(CXX_17_TEST_TARGETS
+  benchmark_so2
+  benchmark_se2
+  benchmark_so3
+  benchmark_se3
+  benchmark_se_2_3
+  benchmark_rn
+
+  benchmark_manif
+
+  benchmark_quat
+)
+
+# Set required C++17 flag
+set_property(TARGET ${CXX_17_TEST_TARGETS} PROPERTY CXX_STANDARD 17)
+set_property(TARGET ${CXX_17_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET ${CXX_17_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -23,10 +23,6 @@ function(manif_add_benchmark target)
     target_compile_options(${target} PRIVATE
       -Werror=all
       -Werror=extra
-      -Wno-unknown-pragmas
-      -Wno-sign-compare
-      -Wno-unused-parameter
-      -Wno-missing-field-initializers
       # When the library is built using GCC it is necessary to link
       # with the pthread library due to how GCC implements std::thread.
       # See https://github.com/google/benchmark#platform-specific-build-instructions

--- a/benchmark/benchmark_manif.cpp
+++ b/benchmark/benchmark_manif.cpp
@@ -1,0 +1,14 @@
+#include "common_benchmark.h"
+
+#include <manif/manif.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(R5d)
+MANIF_BENCHMARK(SO2d)
+MANIF_BENCHMARK(SE2d)
+MANIF_BENCHMARK(SO3d)
+MANIF_BENCHMARK(SE3d)
+MANIF_BENCHMARK(SE_2_3d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_quat.cpp
+++ b/benchmark/benchmark_quat.cpp
@@ -1,0 +1,117 @@
+#include <manif/manif.h>
+
+#include <benchmark/benchmark.h>
+
+template<typename Scalar>
+void normalizeQuat(Eigen::Quaternion<Scalar>& q) {
+  // see https://github.com/zarathustr/quat_norm
+  q.coeffs() /= q.coeffs().cwiseAbs().maxCoeff();
+  for (char j = 0; j < 3; ++j) {
+    const Scalar N = q.squaredNorm();
+    q.coeffs() *= (5.0 + N) / (2.0 + 4.0 * N);
+  }
+}
+
+Eigen::Quaternion<double> randQuat() {
+  // @note: We are using:
+  // http://mathworld.wolfram.com/HyperspherePointPicking.html
+  using std::sqrt;
+  using Scalar = double;
+  using Quaternion = Eigen::Quaternion<Scalar>;
+
+  Scalar u1, u2;
+  do {
+    u1 = Eigen::internal::random<Scalar>(-1, 1),
+    u2 = Eigen::internal::random<Scalar>(-1, 1);
+  } while (u1 * u1 + u2 * u2 > Scalar(1));
+
+  Scalar u3, u4, n;
+  do {
+    u3 = Eigen::internal::random<Scalar>(-1, 1),
+    u4 = Eigen::internal::random<Scalar>(-1, 1);
+    n = u3 * u3 + u4 * u4;
+  } while (n > Scalar(1.0));
+
+  const Scalar zw_factor = sqrt((Scalar(1) - u1 * u1 - u2 * u2) / n);
+  return Quaternion(u1, u2, u3 * zw_factor, u4 * zw_factor);
+}
+
+// Normalization benchmark
+
+static void BM_EigenNormalize(benchmark::State& state) {
+  Eigen::Quaternion<double> q;
+  // Use the underlying vector random so that
+  // the quaternion isn't normalized already
+  q.coeffs().setRandom();
+  double norm=0;
+  for (auto _ : state) {
+
+    q.normalize();
+
+    state.PauseTiming();
+    norm += q.norm();
+    q.coeffs().setRandom();
+    state.ResumeTiming();
+  }
+  state.counters["normAvg"] = benchmark::Counter(
+    norm, benchmark::Counter::kAvgIterations
+  );
+}
+BENCHMARK(BM_EigenNormalize);
+
+static void BM_normalizeQuat(benchmark::State& state) {
+  Eigen::Quaternion<double> q;
+  // Use the underlying vector random so that
+  // the quaternion isn't normalized already
+  q.coeffs().setRandom();
+  double norm=0;
+  for (auto _ : state) {
+
+    normalizeQuat(q);
+
+    state.PauseTiming();
+    norm += q.norm();
+    q.coeffs().setRandom();
+    state.ResumeTiming();
+  }
+  state.counters["normAvg"] = benchmark::Counter(
+    norm, benchmark::Counter::kAvgIterations
+  );
+}
+BENCHMARK(BM_normalizeQuat);
+
+// Random benchmark
+
+static void BM_UnitRandom(benchmark::State& state) {
+  Eigen::Quaternion<double> q;
+  double norm=0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(q = manif::randQuat<double>());
+
+    state.PauseTiming();
+    norm += q.norm();
+    state.ResumeTiming();
+  }
+  state.counters["normAvg"] = benchmark::Counter(
+    norm, benchmark::Counter::kAvgIterations
+  );
+}
+BENCHMARK(BM_UnitRandom);
+
+static void BM_RandQuat(benchmark::State& state) {
+  Eigen::Quaternion<double> q;
+  double norm=0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(q = randQuat());
+
+    state.PauseTiming();
+    norm += q.norm();
+    state.ResumeTiming();
+  }
+  state.counters["normAvg"] = benchmark::Counter(
+    norm, benchmark::Counter::kAvgIterations
+  );
+}
+BENCHMARK(BM_RandQuat);
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_rn.cpp
+++ b/benchmark/benchmark_rn.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/Rn.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(R5d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_se2.cpp
+++ b/benchmark/benchmark_se2.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/SE2.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(SE2d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_se3.cpp
+++ b/benchmark/benchmark_se3.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/SE3.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(SE3d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_se_2_3.cpp
+++ b/benchmark/benchmark_se_2_3.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/SE_2_3.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(SE_2_3d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_so2.cpp
+++ b/benchmark/benchmark_so2.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/SO2.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(SO2d)
+
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_so3.cpp
+++ b/benchmark/benchmark_so3.cpp
@@ -1,0 +1,9 @@
+#include "common_benchmark.h"
+
+#include <manif/SO3.h>
+
+using namespace manif;
+
+MANIF_BENCHMARK(SO3d)
+
+BENCHMARK_MAIN();

--- a/benchmark/common_benchmark.h
+++ b/benchmark/common_benchmark.h
@@ -1,0 +1,248 @@
+#ifndef _MANIF_BENCHMARK_COMMON_BENCHMARK_H_
+#define _MANIF_BENCHMARK_COMMON_BENCHMARK_H_
+
+#include <benchmark/benchmark.h>
+
+#define MANIF_BENCHMARK(manifold)                                 \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_INVERSE, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalInverse(); }    \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_INVERSE_JAC, manifold        \
+  )(benchmark::State& st) { for (auto _ : st) evalInverseJac(); } \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RPLUS, manifold              \
+  )(benchmark::State& st) { for (auto _ : st) evalRplus(); }      \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RPLUS_JAC, manifold          \
+  )(benchmark::State& st) { for (auto _ : st) evalRplusJac(); }   \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LPLUS, manifold              \
+  )(benchmark::State& st) { for (auto _ : st) evalLplus(); }      \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LPLUS_JAC, manifold          \
+  )(benchmark::State& st) { for (auto _ : st) evalLplusJac(); }   \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RMINUS, manifold             \
+  )(benchmark::State& st) { for (auto _ : st) evalRminus(); }     \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RMINUS_JAC, manifold         \
+  )(benchmark::State& st) { for (auto _ : st) evalRminusJac(); }  \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LMINUS, manifold             \
+  )(benchmark::State& st) { for (auto _ : st) evalLminus(); }     \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LMINUS_JAC, manifold         \
+  )(benchmark::State& st) { for (auto _ : st) evalLminusJac(); }  \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_COMPOSE, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalCompose(); }    \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_COMPOSE_JAC, manifold        \
+  )(benchmark::State& st) { for (auto _ : st) evalComposeJac(); } \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_BETWEEN, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalBetween(); }    \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_BETWEEN_JAC, manifold        \
+  )(benchmark::State& st) { for (auto _ : st) evalBetweenJac(); } \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_ACT, manifold                \
+  )(benchmark::State& st) { for (auto _ : st) evalAct(); }        \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_ACT_JAC, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalActJac(); }     \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LOG, manifold                \
+  )(benchmark::State& st) { for (auto _ : st) evalLog(); }        \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LOG_JAC, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalLogJac(); }     \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_EXP, manifold                \
+  )(benchmark::State& st) { for (auto _ : st) evalExp(); }        \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_EXP_JAC, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalExpJac(); }     \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_HAT, manifold                \
+  )(benchmark::State& st) { for (auto _ : st) evalHat(); }        \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_ADJ, manifold                \
+  )(benchmark::State& st) { for (auto _ : st) evalAdj(); }        \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_SMALL_ADJ, manifold          \
+  )(benchmark::State& st) { for (auto _ : st) evalSmallAdj(); }   \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_INNER, manifold              \
+  )(benchmark::State& st) { for (auto _ : st) evalInner(); }      \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RJAC, manifold               \
+  )(benchmark::State& st) { for (auto _ : st) evalRJac(); }       \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_RJACINV, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalRJacInv(); }    \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LJAC, manifold               \
+  )(benchmark::State& st) { for (auto _ : st) evalLJac(); }       \
+  BENCHMARK_TEMPLATE_F(                                           \
+    CommonBenchmark, BM_##manifold##_LJACINV, manifold            \
+  )(benchmark::State& st) { for (auto _ : st) evalLJacInv(); }
+
+template <typename _LieGroup>
+class CommonBenchmark : public benchmark::Fixture {
+
+  using LieGroup = _LieGroup;
+  using Scalar = typename LieGroup::Scalar;
+  using Tangent = typename LieGroup::Tangent;
+  using Jacobian = typename LieGroup::Jacobian;
+  using LieAlg = typename Tangent::LieAlg;
+  using Point = typename LieGroup::Vector;
+
+public:
+
+  void SetUp(const benchmark::State&) override {
+
+    // Maybe is it better to compare the same seed here.
+    // std::srand((unsigned int) time(0));
+
+    state       = LieGroup::Random();
+    state_other = LieGroup::Random();
+
+    delta = Tangent::Random();
+    delta_other = Tangent::Random();
+
+    pa.setRandom();
+  }
+
+  void evalInverse() {
+    state_new = state.inverse();
+  }
+
+  void evalInverseJac() {
+    state_new = state.inverse(Ja);
+  }
+
+  void evalRplus() {
+    state_new = state.rplus(delta);
+  }
+
+  void evalRplusJac() {
+    state_new = state.rplus(delta, Ja, Jb);
+  }
+
+  void evalLplus() {
+    state_new = state.lplus(delta);
+  }
+
+  void evalLplusJac() {
+    state_new = state.lplus(delta, Ja, Jb);
+  }
+
+  void evalRminus() {
+    delta_new = state.rminus(state_other);
+  }
+
+  void evalRminusJac() {
+    delta_new = state.rminus(state_other, Ja, Jb);
+  }
+
+  void evalLminus() {
+    delta_new = state.lminus(state_other);
+  }
+
+  void evalLminusJac() {
+    delta_new = state.lminus(state_other, Ja, Jb);
+  }
+
+  void evalCompose() {
+    state_new = state.compose(state_other);
+  }
+
+  void evalComposeJac() {
+    state_new = state.compose(state_other, Ja, Jb);
+  }
+
+  void evalBetween() {
+    state_new = state.between(state_other);
+  }
+
+  void evalBetweenJac() {
+    state_new = state.between(state_other, Ja, Jb);
+  }
+
+  void evalAct() {
+    pb = state.act(pa);
+  }
+
+  void evalActJac() {
+    // pb = state.act(pa, Ja, Jb);
+  }
+
+  void evalLog() {
+    delta_new = state.log();
+  }
+
+  void evalLogJac() {
+    delta_new = state.log(Ja);
+  }
+
+  void evalExp() {
+    state_new = delta.exp();
+  }
+
+  void evalExpJac() {
+    state_new = delta.exp(Ja);
+  }
+
+  void evalHat() {
+    hat = delta.hat();
+  }
+
+  void evalAdj() {
+    Ja = state.adj();
+  }
+
+  void evalSmallAdj() {
+    Ja = delta.smallAdj();
+  }
+
+  void evalInner() {
+    inner = delta.inner(delta_other);
+  }
+
+  void evalRJac() {
+    Ja = delta.rjac();
+  }
+
+  void evalRJacInv() {
+    Ja = delta.rjacinv();
+  }
+
+  void evalLJac() {
+    Ja = delta.ljac();
+  }
+
+  void evalLJacInv() {
+    Ja = delta.ljacinv();
+  }
+
+protected:
+
+  Scalar inner;
+
+  LieGroup state;
+  LieGroup state_other;
+  LieGroup state_new;
+
+  Tangent  delta;
+  Tangent  delta_other;
+  Tangent  delta_new;
+
+  Point pa, pb;
+
+  Jacobian Ja, Jb;
+  LieAlg hat;
+};
+
+#endif // _MANIF_BENCHMARK_COMMON_BENCHMARK_H_

--- a/docs/pages/projects.md
+++ b/docs/pages/projects.md
@@ -11,6 +11,8 @@ You may find on Google Scholar publications citing either:
 
 - [`lie-group-controllers`][lie-group-controllers-repo], header-only C++ libraries containing controllers designed for Lie Groups.
 - [`bipedal-locomotion-framework`][bipedal-locomotion-framework], The BipedalLocomotionFramework project is a suite of libraries for achieving bipedal locomotion on humanoid robots.
+- [`kalmanif`][kalmanif], A small collection of Kalman Filters on Lie groups.
+- [`cpp_filter`][cpp_filter], Kalman filter using C++ and Manif.
 
 Your project is not listed here? Let us know about it!
 
@@ -23,3 +25,5 @@ Your project is not listed here? Let us know about it!
 
 [lie-group-controllers-repo]: https://github.com/dic-iit/lie-group-controllers
 [bipedal-locomotion-framework]: https://github.com/dic-iit/bipedal-locomotion-framework
+[kalmanif]: https://github.com/artivis/kalmanif
+[cpp_filter]: https://github.com/aalbaali/cpp_filter

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -45,10 +45,6 @@ foreach(target ${CXX_11_EXAMPLE_TARGETS})
     target_compile_options(${target} PRIVATE
       -Werror=all
       -Werror=extra
-      -Wno-unknown-pragmas
-      -Wno-sign-compare
-      -Wno-unused-parameter
-      -Wno-missing-field-initializers
       )
   endif()
 

--- a/examples/se2_average.cpp
+++ b/examples/se2_average.cpp
@@ -1,6 +1,8 @@
 #include "manif/SE2.h"
 #include "manif/algorithms/average.h"
 
+#include<Eigen/StdVector>
+
 #include <vector>
 #include <iostream>
 
@@ -12,7 +14,7 @@ int main(int /*argc*/, char** /*argv*/)
 {
   // Generate 4 'close' points
 
-  std::vector<manif::SE2d> points;
+  std::vector<manif::SE2d, Eigen::aligned_allocator<manif::SE2d>> points;
 
 //  points.emplace_back(1, 1, 3.*MANIF_PI/4.);
 //  points.emplace_back(1, 3, 5.*MANIF_PI/8.);

--- a/examples/se2_interpolation.cpp
+++ b/examples/se2_interpolation.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
 
   // Intermediate points
 
-  for (int n=1; n<points.size()-1; ++n)
+  for (std::size_t n=1; n<points.size()-1; ++n)
   {
     const manif::SE2d& s0 = points[ n ];
     const manif::SE2d& s1 = points[n+1];

--- a/examples/se2_localization.cpp
+++ b/examples/se2_localization.cpp
@@ -215,7 +215,7 @@ int main()
         X_simulation = X_simulation + u_simu;               // overloaded X.rplus(u) = X * exp(u)
 
         /// then we measure all landmarks - - - - - - - - - - - - - - - - - - - -
-        for (int i = 0; i < landmarks.size(); i++)
+        for (std::size_t i = 0; i < landmarks.size(); i++)
         {
             b = landmarks[i];                               // lmk coordinates in world frame
 

--- a/examples/se2_localization_ukfm.cpp
+++ b/examples/se2_localization_ukfm.cpp
@@ -284,7 +284,7 @@ int main()
         X_simulation = X_simulation + u_simu;               // overloaded X.rplus(u) = X * exp(u)
 
         /// then we measure all landmarks - - - - - - - - - - - - - - - - - - - -
-        for (int i = 0; i < landmarks.size(); i++)
+        for (std::size_t i = 0; i < landmarks.size(); i++)
         {
             b = landmarks[i];                               // lmk coordinates in world frame
 

--- a/examples/se3_localization.cpp
+++ b/examples/se3_localization.cpp
@@ -221,7 +221,7 @@ int main()
         X_simulation = X_simulation + u_simu;               // overloaded X.rplus(u) = X * exp(u)
 
         /// then we measure all landmarks - - - - - - - - - - - - - - - - - - - -
-        for (int i = 0; i < landmarks.size(); i++)
+        for (std::size_t i = 0; i < landmarks.size(); i++)
         {
             b = landmarks[i];                               // lmk coordinates in world frame
 

--- a/examples/se_2_3_localization.cpp
+++ b/examples/se_2_3_localization.cpp
@@ -341,7 +341,7 @@ int main()
         alpha = alpha_const - X_simulation.rotation().transpose()*g; // update expected IMU measurement after moving
 
         /// then we measure all landmarks - - - - - - - - - - - - - - - - - - - -
-        for (int i = 0; i < landmarks.size(); i++)
+        for (std::size_t i = 0; i < landmarks.size(); i++)
         {
             b = landmarks[i];                               // lmk coordinates in world frame
 

--- a/examples/so2_average.cpp
+++ b/examples/so2_average.cpp
@@ -8,7 +8,7 @@
  * @brief An example of the use of the average biinvariant algorithm.
  */
 
-int main(int argc, char** argv)
+int main(int argc, char**)
 {
   if (argc > 1)
   {

--- a/include/manif/impl/lie_group_base.h
+++ b/include/manif/impl/lie_group_base.h
@@ -510,18 +510,18 @@ LieGroupBase<_Derived>::lminus(
 {
   const Tangent t = compose(m.inverse()).log();
 
-  if (J_t_ma || J_t_mb)
+  if (J_t_ma)
   {
-    const Jacobian J = t.rjacinv() * m.adj();
+    J_t_ma->noalias() = t.rjacinv() * m.adj();
 
-    if (J_t_ma)
-    {
-      (*J_t_ma) =  J;
-    }
     if (J_t_mb)
     {
-      (*J_t_mb) = -J;
+      *J_t_mb = -(*J_t_ma);
     }
+  }
+  else if (J_t_mb)
+  {
+    J_t_mb->noalias() = -(t.rjacinv() * m.adj());
   }
 
   return t;

--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -41,6 +41,8 @@ raise(Args&&... args)
 } /* namespace detail */
 } /* namespace manif */
 
+#define MANIF_UNUSED_VARIABLE(x) EIGEN_UNUSED_VARIABLE(x)
+
 // gcc expands __VA_ARGS___ before passing it into the macro.
 // Visual Studio expands __VA_ARGS__ after passing it.
 // This macro is a workaround to support both

--- a/include/manif/impl/se2/SE2Tangent_base.h
+++ b/include/manif/impl/se2/SE2Tangent_base.h
@@ -74,10 +74,20 @@ public:
   Jacobian rjac() const;
 
   /**
+   * @brief Get the inverse right Jacobian of SE2.
+   */
+  Jacobian rjacinv() const;
+
+  /**
    * @brief Get the left Jacobian of SE2.
    * @note See Eq. (164).
    */
   Jacobian ljac() const;
+
+  /**
+   * @brief Get the inverse left Jacobian of SE2.
+   */
+  Jacobian ljacinv() const;
 
   /**
    * @brief
@@ -211,6 +221,55 @@ SE2TangentBase<_Derived>::rjac() const
 
 template <typename _Derived>
 typename SE2TangentBase<_Derived>::Jacobian
+SE2TangentBase<_Derived>::rjacinv() const
+{
+  using std::abs;
+  using std::cos;
+  using std::sin;
+
+  const Scalar theta = angle();
+  const Scalar cos_theta = cos(theta);
+  const Scalar sin_theta = sin(theta);
+  const Scalar theta_sq = theta * theta;
+
+  Scalar A,  // theta_sin_theta
+         B;  // theta_cos_theta
+
+  A = theta*sin_theta;
+  B = theta*cos_theta;
+
+  Jacobian Jrinv;
+
+  Jrinv(0,1) = -theta*Scalar(0.5);
+  Jrinv(1,0) = -Jrinv(0,1);
+
+  if (theta_sq > Constants<Scalar>::eps)
+  {
+    Jrinv(0,0) = -A/(Scalar(2)*cos_theta-Scalar(2));
+    Jrinv(1,1) =  Jrinv(0,0);
+
+    Scalar den = Scalar(2)*theta*(cos_theta-Scalar(1));
+    Jrinv(0,2) = (A*x() + B*y() - theta*y() + Scalar(2)*x()*cos_theta - Scalar(2)*x()) / den;
+    Jrinv(1,2) = (-B*x() + A*y() + theta*x() + Scalar(2)*y()*cos_theta - Scalar(2)*y()) / den;
+  }
+  else
+  {
+    Jrinv(0,0) = Scalar(1)-theta_sq/Scalar(12);
+    Jrinv(1,1) =  Jrinv(0,0);
+
+    Jrinv(0,2) =  y()/Scalar(2) + theta*x()/Scalar(12);
+    Jrinv(1,2) = -x()/Scalar(2) + theta*y()/Scalar(12);
+  }
+
+  Jrinv(2,0) = Scalar(0);
+  Jrinv(2,1) = Scalar(0);
+  Jrinv(2,2) = Scalar(1);
+
+  return Jrinv;
+}
+
+template <typename _Derived>
+typename SE2TangentBase<_Derived>::Jacobian
 SE2TangentBase<_Derived>::ljac() const
 {
   using std::cos;
@@ -255,6 +314,55 @@ SE2TangentBase<_Derived>::ljac() const
   }
 
   return Jl;
+}
+
+template <typename _Derived>
+typename SE2TangentBase<_Derived>::Jacobian
+SE2TangentBase<_Derived>::ljacinv() const
+{
+  using std::abs;
+  using std::cos;
+  using std::sin;
+
+  const Scalar theta = angle();
+  const Scalar cos_theta = cos(theta);
+  const Scalar sin_theta = sin(theta);
+  const Scalar theta_sq = theta * theta;
+
+  Scalar A,  // theta_sin_theta
+         B;  // theta_cos_theta
+
+  A = theta*sin_theta;
+  B = theta*cos_theta;
+
+  Jacobian Jlinv;
+
+  Jlinv(0,1) =  theta*Scalar(0.5);
+  Jlinv(1,0) = -Jlinv(0,1);
+
+  if (theta_sq > Constants<Scalar>::eps)
+  {
+    Jlinv(0,0) = -A/(Scalar(2)*cos_theta-Scalar(2));
+    Jlinv(1,1) =  Jlinv(0,0);
+
+    Scalar den = Scalar(2)*theta*(cos_theta-Scalar(1));
+    Jlinv(0,2) = (A*x() - B*y() + theta*y() + Scalar(2)*x()*cos_theta - Scalar(2)*x()) / den;
+    Jlinv(1,2) = (B*x() + A*y() - theta*x() + Scalar(2)*y()*cos_theta - Scalar(2)*y()) / den;
+  }
+  else
+  {
+    Jlinv(0,0) = Scalar(1)-theta_sq/Scalar(12);
+    Jlinv(1,1) = Jlinv(0,0);
+
+    Jlinv(0,2) = -y()/Scalar(2) + theta*x()/Scalar(12);
+    Jlinv(1,2) =  x()/Scalar(2) + theta*y()/Scalar(12);
+  }
+
+  Jlinv(2,0) = Scalar(0);
+  Jlinv(2,1) = Scalar(0);
+  Jlinv(2,2) = Scalar(1);
+
+  return Jlinv;
 }
 
 template <typename _Derived>

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -166,7 +166,7 @@ typename SE2Base<_Derived>::Transformation
 SE2Base<_Derived>::transform() const
 {
   Transformation T(Transformation::Identity());
-  T.template block<2,2>(0,0) = rotation();
+  T.template topLeftCorner<2,2>() = rotation();
   T(0,2) = x();
   T(1,2) = y();
   return T;

--- a/include/manif/impl/se2/SE2_base.h
+++ b/include/manif/impl/se2/SE2_base.h
@@ -420,6 +420,7 @@ struct AssignmentEvaluatorImpl<SE2Base<Derived>>
       "SE2 assigned data not normalized !",
       invalid_argument
     );
+    MANIF_UNUSED_VARIABLE(data);
   }
 };
 

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -386,12 +386,13 @@ SE3Base<_Derived>::adj() const
   ///
   /// considering vee(log(g)) = (v;w)
 
-  Jacobian Adj = Jacobian::Zero();
+  Jacobian Adj;
   Adj.template topLeftCorner<3,3>() = rotation();
   Adj.template bottomRightCorner<3,3>() =
       Adj.template topLeftCorner<3,3>();
-  Adj.template topRightCorner<3,3>() =
+  Adj.template topRightCorner<3,3>().noalias() =
     skew(translation()) * Adj.template topLeftCorner<3,3>();
+  Adj.template bottomLeftCorner<3,3>().setZero();
 
   return Adj;
 }

--- a/include/manif/impl/se3/SE3_base.h
+++ b/include/manif/impl/se3/SE3_base.h
@@ -457,6 +457,7 @@ struct AssignmentEvaluatorImpl<SE3Base<Derived>>
       "SE3 assigned data not normalized !",
       manif::invalid_argument
     );
+    MANIF_UNUSED_VARIABLE(data);
   }
 };
 

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
@@ -166,17 +166,15 @@ SE_2_3TangentBase<_Derived>::rjac() const
 
   // fill Qv
   Eigen::Matrix<Scalar, 6, 1> vw;
-  vw << Scalar(-coeffs()(0)), Scalar(-coeffs()(1)), Scalar(-coeffs()(2)),
-        Scalar(-coeffs()(3)), Scalar(-coeffs()(4)), Scalar(-coeffs()(5));
-  Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>> Qv = Jr.template block<3,3>(0, 3);
-  SE3Tangent<Scalar>::fillQ(Qv, vw);
+  vw << -coeffs()(0), -coeffs()(1), -coeffs()(2),
+        -coeffs()(3), -coeffs()(4), -coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jr.template block<3,3>(0, 3), vw);
 
   // fill Qa
   Eigen::Matrix<Scalar, 6, 1> aw;
-  aw << Scalar(-coeffs()(6)), Scalar(-coeffs()(7)), Scalar(-coeffs()(8)),
-        Scalar(-coeffs()(3)), Scalar(-coeffs()(4)), Scalar(-coeffs()(5));
-  Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>> Qa = Jr.template block<3,3>(6, 3);
-  SE3Tangent<Scalar>::fillQ(Qa, aw);
+  aw << -coeffs()(6), -coeffs()(7), -coeffs()(8),
+        -coeffs()(3), -coeffs()(4), -coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jr.template block<3,3>(6, 3), aw);
 
   return Jr;
 }
@@ -194,17 +192,15 @@ SE_2_3TangentBase<_Derived>::ljac() const
 
   // fill Qv
   Eigen::Matrix<Scalar, 6, 1> vw;
-  vw << Scalar(coeffs()(0)), Scalar(coeffs()(1)), Scalar(coeffs()(2)),
-        Scalar(coeffs()(3)), Scalar(coeffs()(4)), Scalar(coeffs()(5));
-  Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>> Qv = Jl.template block<3,3>(0, 3);
-  SE3Tangent<Scalar>::fillQ(Qv, vw);
+  vw << coeffs()(0), coeffs()(1), coeffs()(2),
+        coeffs()(3), coeffs()(4), coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jl.template block<3,3>(0, 3), vw);
 
   // fill Qa
   Eigen::Matrix<Scalar, 6, 1> aw;
-  aw << Scalar(coeffs()(6)), Scalar(coeffs()(7)), Scalar(coeffs()(8)),
-        Scalar(coeffs()(3)), Scalar(coeffs()(4)), Scalar(coeffs()(5));
-  Eigen::Ref<Eigen::Matrix<Scalar, 3, 3>> Qa = Jl.template block<3,3>(6, 3);
-  SE3Tangent<Scalar>::fillQ(Qa, aw);
+  aw << coeffs()(6), coeffs()(7), coeffs()(8),
+        coeffs()(3), coeffs()(4), coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jl.template block<3,3>(6, 3), aw);
 
   return Jl;
 }

--- a/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3Tangent_base.h
@@ -78,9 +78,19 @@ public:
   Jacobian rjac() const;
 
   /**
+   * @brief Get the inverse right Jacobian of SE_2_3.
+   */
+  Jacobian rjacinv() const;
+
+  /**
    * @brief Get the left Jacobian of SE_2_3.
    */
   Jacobian ljac() const;
+
+  /**
+   * @brief Get the inverse left Jacobian of SE_2_3.
+   */
+  Jacobian ljacinv() const;
 
   /**
    * @brief Get the small adjoint matrix ad() of SE_2_3
@@ -165,10 +175,9 @@ SE_2_3TangentBase<_Derived>::rjac() const
   Jr.template bottomRightCorner<3, 3>() = Jr.template topLeftCorner<3,3>();
 
   // fill Qv
-  Eigen::Matrix<Scalar, 6, 1> vw;
-  vw << -coeffs()(0), -coeffs()(1), -coeffs()(2),
-        -coeffs()(3), -coeffs()(4), -coeffs()(5);
-  SE3Tangent<Scalar>::fillQ(Jr.template block<3,3>(0, 3), vw);
+  SE3Tangent<Scalar>::fillQ(
+    Jr.template block<3,3>(0, 3), -coeffs().template head<6>()
+  );
 
   // fill Qa
   Eigen::Matrix<Scalar, 6, 1> aw;
@@ -177,6 +186,42 @@ SE_2_3TangentBase<_Derived>::rjac() const
   SE3Tangent<Scalar>::fillQ(Jr.template block<3,3>(6, 3), aw);
 
   return Jr;
+}
+
+template <typename _Derived>
+typename SE_2_3TangentBase<_Derived>::Jacobian
+SE_2_3TangentBase<_Derived>::rjacinv() const
+{
+  Jacobian Jr_inv;
+  Jr_inv.template block<3, 3>(3, 0).setZero();
+  // Jr_inv.template block<3, 3>(6, 0).setZero(); // Serves as temp Q
+  Jr_inv.template block<6, 3>(0, 6).setZero();
+  Jr_inv.template topLeftCorner<3, 3>() = asSO3().rjacinv();
+  Jr_inv.template block<3, 3>(3,3) = Jr_inv.template topLeftCorner<3,3>();
+  Jr_inv.template bottomRightCorner<3, 3>() = Jr_inv.template topLeftCorner<3,3>();
+
+  // fill Qv
+  SE3Tangent<Scalar>::fillQ(
+    Jr_inv.template block<3, 3>(6, 0), -coeffs().template head<6>()
+  );
+  Jr_inv.template block<3, 3>(0, 3).noalias() =
+    -Jr_inv.template topLeftCorner<3,3>() *
+     Jr_inv.template block<3, 3>(6, 0) *
+     Jr_inv.template topLeftCorner<3,3>();
+
+  // fill Qa
+  Eigen::Matrix<Scalar, 6, 1> aw;
+  aw << -coeffs()(6), -coeffs()(7), -coeffs()(8),
+        -coeffs()(3), -coeffs()(4), -coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jr_inv.template block<3, 3>(6, 0), aw);
+  Jr_inv.template block<3, 3>(6, 3).noalias() =
+    -Jr_inv.template topLeftCorner<3,3>() *
+     Jr_inv.template block<3, 3>(6, 0) *
+     Jr_inv.template topLeftCorner<3,3>();
+
+  Jr_inv.template block<3, 3>(6, 0).setZero();
+
+  return Jr_inv;
 }
 
 template <typename _Derived>
@@ -191,10 +236,9 @@ SE_2_3TangentBase<_Derived>::ljac() const
   Jl.template bottomRightCorner<3, 3>() = Jl.template topLeftCorner<3,3>();
 
   // fill Qv
-  Eigen::Matrix<Scalar, 6, 1> vw;
-  vw << coeffs()(0), coeffs()(1), coeffs()(2),
-        coeffs()(3), coeffs()(4), coeffs()(5);
-  SE3Tangent<Scalar>::fillQ(Jl.template block<3,3>(0, 3), vw);
+  SE3Tangent<Scalar>::fillQ(
+    Jl.template block<3,3>(0, 3), coeffs().template head<6>()
+  );
 
   // fill Qa
   Eigen::Matrix<Scalar, 6, 1> aw;
@@ -203,6 +247,42 @@ SE_2_3TangentBase<_Derived>::ljac() const
   SE3Tangent<Scalar>::fillQ(Jl.template block<3,3>(6, 3), aw);
 
   return Jl;
+}
+
+template <typename _Derived>
+typename SE_2_3TangentBase<_Derived>::Jacobian
+SE_2_3TangentBase<_Derived>::ljacinv() const
+{
+  Jacobian Jlinv;
+  Jlinv.template block<3, 3>(3, 0).setZero();
+  // Jlinv.template block<3, 3>(6, 0).setZero(); // Serves as temp Q
+  Jlinv.template block<6, 3>(0, 6).setZero();
+  Jlinv.template topLeftCorner<3, 3>() = asSO3().ljacinv();
+  Jlinv.template block<3, 3>(3, 3) = Jlinv.template topLeftCorner<3,3>();
+  Jlinv.template bottomRightCorner<3, 3>() = Jlinv.template topLeftCorner<3,3>();
+
+  // fill Qv
+  SE3Tangent<Scalar>::fillQ(
+    Jlinv.template block<3, 3>(6, 0), coeffs().template head<6>()
+  );
+  Jlinv.template block<3, 3>(0, 3).noalias() =
+    -Jlinv.template topLeftCorner<3, 3>() *
+     Jlinv.template block<3, 3>(6, 0) *
+     Jlinv.template topLeftCorner<3, 3>();
+
+  // fill Qa
+  Eigen::Matrix<Scalar, 6, 1> aw;
+  aw << coeffs()(6), coeffs()(7), coeffs()(8),
+        coeffs()(3), coeffs()(4), coeffs()(5);
+  SE3Tangent<Scalar>::fillQ(Jlinv.template block<3, 3>(6, 0), aw);
+  Jlinv.template block<3, 3>(6, 3).noalias() =
+    -Jlinv.template topLeftCorner<3, 3>() *
+     Jlinv.template block<3, 3>(6, 0) *
+     Jlinv.template topLeftCorner<3, 3>();
+
+  Jlinv.template block<3, 3>(6, 0).setZero();
+
+  return Jlinv;
 }
 
 template <typename _Derived>

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -198,10 +198,12 @@ template <typename _Derived>
 typename SE_2_3Base<_Derived>::Isometry
 SE_2_3Base<_Derived>::isometry() const
 {
-  Eigen::Matrix<Scalar, 5, 5> T = Eigen::Matrix<Scalar, 5, 5>::Identity();
+  Eigen::Matrix<Scalar, 5, 5> T;
   T.template topLeftCorner<3,3>() = rotation();
   T.template block<3, 1>(0, 3) = translation();
   T.template topRightCorner<3,1>() = linearVelocity();
+  T.template bottomLeftCorner<2,3>().setZero();
+  T.template bottomRightCorner<2,2>().setIdentity();
   return T;
 }
 

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -348,17 +348,20 @@ SE_2_3Base<_Derived>::adj() const
   /// with T = [t]_x
   /// with V = [v]_x
 
-  Jacobian Adj = Jacobian::Zero();
+  Jacobian Adj;
   Adj.template topLeftCorner<3,3>() = rotation();
   Adj.template bottomRightCorner<3,3>() =
       Adj.template topLeftCorner<3,3>();
   Adj.template block<3,3>(3,3) =
       Adj.template topLeftCorner<3,3>();
 
-  Adj.template block<3,3>(0, 3) =
+  Adj.template block<3,3>(0, 3).noalias() =
     skew(translation()) * Adj.template topLeftCorner<3,3>();
-  Adj.template block<3,3>(6, 3) =
+  Adj.template block<3,3>(6, 3).noalias() =
     skew(linearVelocity()) * Adj.template topLeftCorner<3,3>();
+
+  Adj.template bottomLeftCorner<6,3>().setZero();
+  Adj.template topRightCorner<6,3>().setZero();
 
   return Adj;
 }

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -448,6 +448,7 @@ struct AssignmentEvaluatorImpl<SE_2_3Base<Derived>>
       "SE_2_3 assigned data not normalized !",
       manif::invalid_argument
     );
+    MANIF_UNUSED_VARIABLE(data);
   }
 };
 

--- a/include/manif/impl/se_2_3/SE_2_3_base.h
+++ b/include/manif/impl/se_2_3/SE_2_3_base.h
@@ -320,8 +320,8 @@ SE_2_3Base<_Derived>::act(const Eigen::MatrixBase<_EigenDerived> &v,
 
   if (J_vout_m)
   {
-    J_vout_m->template topLeftCorner<3,3>()  =  R;
-    J_vout_m->template block<3,3>(0, 3) = -R * skew(v);
+    J_vout_m->template topLeftCorner<3,3>() = R;
+    J_vout_m->template block<3,3>(0, 3).noalias() = -R * skew(v);
     J_vout_m->template topRightCorner<3,3>().setZero();
   }
 

--- a/include/manif/impl/so2/SO2Tangent_base.h
+++ b/include/manif/impl/so2/SO2Tangent_base.h
@@ -117,7 +117,7 @@ SO2TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
     (*J_m_t) = rjac();
   }
 
-  return LieGroup(cos(coeffs()(0)), sin(coeffs()(0)));
+  return LieGroup(cos(angle()), sin(angle()));
 }
 
 template <typename _Derived>
@@ -132,8 +132,8 @@ typename SO2TangentBase<_Derived>::LieAlg
 SO2TangentBase<_Derived>::hat() const
 {
   return (LieAlg() <<
-    Scalar(0)          , Scalar(-coeffs()(0)),
-    Scalar(coeffs()(0)), Scalar(0)            ).finished();
+    Scalar(0)      , Scalar(-angle()),
+    Scalar(angle()), Scalar(0)        ).finished();
 }
 
 template <typename _Derived>

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -336,6 +336,7 @@ struct AssignmentEvaluatorImpl<SO2Base<Derived>>
       "SO2 assigned data not normalized !",
       invalid_argument
     );
+    MANIF_UNUSED_VARIABLE(data);
   }
 };
 

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -245,7 +245,7 @@ SO2Base<_Derived>::act(const Eigen::MatrixBase<_EigenDerived> &v,
 
   if (J_vout_m)
   {
-    (*J_vout_m) = R * skew(Scalar(1)) * v;
+    J_vout_m->noalias() = R * skew(Scalar(1)) * v;
   }
 
   if (J_vout_v)

--- a/include/manif/impl/so2/SO2_base.h
+++ b/include/manif/impl/so2/SO2_base.h
@@ -154,7 +154,7 @@ typename SO2Base<_Derived>::Transformation
 SO2Base<_Derived>::transform() const
 {
   Transformation T(Transformation::Identity());
-  T.template block<2,2>(0,0) = rotation();
+  T.template topLeftCorner<2, 2>() = rotation();
   return T;
 }
 

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -124,20 +124,17 @@ SO3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
 
   const DataType& theta_vec = coeffs();
   const Scalar theta_sq = theta_vec.squaredNorm();
-  const Scalar theta    = sqrt(theta_sq);
 
   if (theta_sq > Constants<Scalar>::eps)
   {
+    const Scalar theta = sqrt(theta_sq);
     if (J_m_t)
     {
-      Jacobian M1, M2;
-
       const LieAlg W = hat();
 
-      M1.noalias() = (Scalar(1.0) - cos(theta)) / theta_sq * W;
-      M2.noalias() = (theta - sin(theta)) / (theta_sq * theta) * (W * W);;
-
-      *J_m_t = Jacobian::Identity() - M1 + M2;
+      J_m_t->setIdentity();
+      J_m_t->noalias() -= (Scalar(1.0) - cos(theta)) / theta_sq * W;
+      J_m_t->noalias() += (theta - sin(theta)) / (theta_sq * theta) * W * W;
     }
 
     return LieGroup( Eigen::AngleAxis<Scalar>(theta, theta_vec.normalized()) );
@@ -146,7 +143,8 @@ SO3TangentBase<_Derived>::exp(OptJacobianRef J_m_t) const
   {
     if (J_m_t)
     {
-      *J_m_t = Jacobian::Identity() - Scalar(0.5) * hat();
+      J_m_t->setIdentity();
+      J_m_t->noalias() -= Scalar(0.5) * hat();
     }
 
     return LieGroup(x()/Scalar(2), y()/Scalar(2), z()/Scalar(2), Scalar(1));

--- a/include/manif/impl/so3/SO3Tangent_base.h
+++ b/include/manif/impl/so3/SO3Tangent_base.h
@@ -182,11 +182,10 @@ SO3TangentBase<_Derived>::ljac() const
     return Jacobian::Identity() + Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle
-  Jacobian M1, M2;
-  M1.noalias() = (Scalar(1) - cos(theta)) / theta_sq * W;
-  M2.noalias() = (theta - sin(theta)) / (theta_sq * theta) * (W * W);
 
-  return Jacobian::Identity() + M1 + M2;
+  return Jacobian::Identity() +
+    (Scalar(1) - cos(theta)) / theta_sq * W +
+    (theta - sin(theta)) / (theta_sq * theta) * W * W;
 }
 
 template <typename _Derived>
@@ -212,12 +211,11 @@ SO3TangentBase<_Derived>::ljacinv() const
     return Jacobian::Identity() - Scalar(0.5) * W;
 
   const Scalar theta = sqrt(theta_sq); // rotation angle
-  Jacobian M;
-  M.noalias() = (Scalar(1) / theta_sq -
-                 (Scalar(1) + cos(theta)) /
-                 (Scalar(2) * theta * sin(theta))) * (W * W);
 
-  return Jacobian::Identity() - Scalar(0.5) * W + M;
+  return Jacobian::Identity() -
+    Scalar(0.5) * W +
+    (Scalar(1) / theta_sq - (Scalar(1) + cos(theta)) / (Scalar(2) * theta * sin(theta))) *
+    W * W;
 }
 
 template <typename _Derived>

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -417,6 +417,7 @@ struct AssignmentEvaluatorImpl<SO3Base<Derived>>
       "SO3 assigned data not normalized !",
       manif::invalid_argument
     );
+    MANIF_UNUSED_VARIABLE(data);
   }
 };
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -154,7 +154,7 @@ typename SO3Base<_Derived>::Transformation
 SO3Base<_Derived>::transform() const
 {
   Transformation T = Transformation::Identity();
-  T.template block<3,3>(0,0) = rotation();
+  T.template topLeftCorner<3,3>() = rotation();
   return T;
 }
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -236,16 +236,15 @@ SO3Base<_Derived>::log(OptJacobianRef J_t_m) const
 
   if (J_t_m)
   {
+    J_t_m->setIdentity();
+    J_t_m->noalias() += Scalar(0.5) * tan.hat();
     Scalar theta2 = tan.coeffs().squaredNorm();
-    typename Tangent::LieAlg W = tan.hat();
-    if (theta2 <= Constants<Scalar>::eps)
-      J_t_m->noalias() = Jacobian::Identity() + Scalar(0.5) * W; // Small angle approximation
-    else
+    if (theta2 > Constants<Scalar>::eps)
     {
       Scalar theta = sqrt(theta2);  // rotation angle
-      Jacobian M;
-      M.noalias() = (Scalar(1) / theta2 - (Scalar(1) + cos(theta)) / (Scalar(2) * theta * sin(theta))) * (W * W);
-      J_t_m->noalias() = Jacobian::Identity() + Scalar(0.5) * W + M; //is this really more optimized?
+      J_t_m->noalias() +=
+        (Scalar(1) / theta2 - (Scalar(1) + cos(theta)) / (Scalar(2) * theta * sin(theta))) *
+        tan.hat() * tan.hat();
     }
   }
 

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -306,7 +306,7 @@ SO3Base<_Derived>::act(const Eigen::MatrixBase<_EigenDerived> &v,
 
   if (J_vout_m)
   {
-    (*J_vout_m) = -R * skew(v);
+    J_vout_m->noalias() = -R * skew(v);
   }
 
   if (J_vout_v)

--- a/include/manif/impl/so3/SO3_base.h
+++ b/include/manif/impl/so3/SO3_base.h
@@ -288,8 +288,7 @@ SO3Base<_Derived>::compose(
 
   if (abs(ret_sqnorm-Scalar(1)) > Constants<Scalar>::eps)
   {
-    const Scalar scale = approxSqrtInv(ret_sqnorm);
-    ret_q.coeffs() *= scale;
+    ret_q.coeffs() *= approxSqrtInv(ret_sqnorm);
   }
 
   return LieGroup(ret_q);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,10 +42,6 @@ function(manif_add_gtest target)
     target_compile_options(${target} PRIVATE
       -Werror=all
       -Werror=extra
-      -Wno-unknown-pragmas
-      -Wno-sign-compare
-      -Wno-unused-parameter
-      -Wno-missing-field-initializers
       )
   endif()
 

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -6,6 +6,8 @@
 #include "manif/algorithms/interpolation.h"
 #include "manif/algorithms/average.h"
 
+#include <Eigen/StdVector>
+
 #define MANIF_TEST(manifold)                                              \
   using TEST_##manifold##_TESTER = CommonTester<manifold>;                \
   INSTANTIATE_TEST_CASE_P(                                                \
@@ -80,7 +82,7 @@
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_INTERP)              \
   { evalInterp(); }                                                       \
   TEST_F(TEST_##manifold##_TESTER, TEST_##manifold##_AVG_BIINVARIANT)     \
-  { /*evalAvgBiInvariant();*/ }                                               \
+  { evalAvgBiInvariant(); }                                               \
   TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_IS_APPROX)           \
   { evalIsApprox(); }                                                     \
   TEST_P(TEST_##manifold##_TESTER, TEST_##manifold##_UNARY_MINUS)         \
@@ -463,19 +465,19 @@ public:
   {
     // Note : average works over points that are 'close'.
 
-    EXPECT_THROW(average_biinvariant(std::vector<LieGroup>{}),
+    EXPECT_THROW(average_biinvariant(std::vector<LieGroup, Eigen::aligned_allocator<LieGroup>>{}),
                  std::runtime_error);
 
     {
       const auto dummy = LieGroup::Random();
-      std::vector<LieGroup> tmp;
+      std::vector<LieGroup, Eigen::aligned_allocator<LieGroup>> tmp;
       tmp.push_back(dummy);
       EXPECT_MANIF_NEAR(dummy, average_biinvariant(tmp), tol_);
     }
 
     const LieGroup centroid = LieGroup::Random();
 
-    std::vector<LieGroup> mans;
+    std::vector<LieGroup, Eigen::aligned_allocator<LieGroup>> mans;
 
     // Generate N points arround the centroid
     const int N = 15;


### PR DESCRIPTION
- Add benchmark
- some small opti
- `SE2Tangent::rjacinv/ljacinv`
- `SE_2_3Tangent::rjacinv/ljacinv`
- fix average unit test
- run tests in debug and release on ubuntu.

This PR adds some micro benchmarks using [Google benchmark](https://github.com/google/benchmark). This allows to have some time-based benchmarks on a per-function basis so that one can compare different implementations.

The PR also contains numerous small optimizations, most of which do not actually show any benefit in the aforementioned benchmark. Those which do are listed below. 
Most noticeably, implementing `SE2Tangent::rjacinv/ljacinv` (~6x / ~4.3x) and `SE_2_3Tangent::rjacinv/ljacinv` (~4.5x / ~5x) are a big win.

It also remove some unnecessary cmake warning suppression for the test/examples, fix the `average` unit test that was disabled and finally it runs the unit test both in Debug and Release on Ubuntu.

Some numbers obtained through the benchmarking introduced in this PR:

| Group | Operation  |       | Before |       | After |
| :--- |   :---:   |   :---:   | :---: | :---: | :---: |
|SE2|rjacinv|||||
|(mean)|        | | 49.6 ns   | | 8.41 ns   |
|(median)|      | | 49.6 ns   | | 8.39 ns   |
|(stddev)|      | | 3.69 ns   | | 0.102 ns  |
||ljacinv|||||
||              | | 37.1 ns   | | 8.48 ns   |
||              | | 37.3 ns   | | 8.46 ns   |
||              | | 3.77 ns   | | 0.097 ns  |
|SE_2_3|rjacinv|||||
||              | | 1570 ns   | | 349 ns    |
||              | | 1539 ns   | | 354 ns    |
||              | | 72.8 ns   | | 9.76 ns   |
||ljacinv|||||
||              | | 1722 ns   | | 338 ns    |
||              | | 1706 ns   | | 337 ns    |
||              | | 68.4 ns   | | 11.0 ns   |
||adj|||||
||              | | 100 ns    | | 76.1 ns   |
||              | | 100 ns    | | 75.8 ns   |
||              | | 1.11 ns   | | 1.45 ns   |

As a bonus, here is compared the unit quaternion random implementation from `Eigen` and the one proposed in #105. Note that currently `manif` still uses the implementation from `Eigen` as I don't see a strong motivation to introduce some new code to support for a non critical function. Rather than changing `manif` implementation I'd suggest to propose the change directly upstream to `Eigen`.

|  | Operation  |       | Before |       | After |
| :--- |   :---:   |   :---:   | :---: | :---: | :---: |
|*quaternion*|random|||||
||              | | 524 ns    | | 491 ns    |
||              | | 523 ns    | | 490 ns    |
||              | | 2.04 ns   | | 1.99 ns   |