### PR TITLE
Fix doc generation in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,9 @@ name: documentation
 on:
   push:
     branches: devel
+  pull_request:
+    branches:
+      - devel
   workflow_dispatch:
 
 jobs:
@@ -27,10 +30,9 @@ jobs:
       - name: Setup
         run: |
           python -m pip install --upgrade pip
-          pip install pytest "pybind11[global]"
-          pip install -r requirements.txt
+          python -m pip install build
       - name: Build
-        run: pip install .
+        run: python -m pip install -v .
 
   # build:
   #   runs-on: ubuntu-20.04
@@ -86,6 +88,10 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     needs: [build]
+    # todo: deploy if new tag/release
+    if: |
+      github.repository == 'artivis/manif' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/devel'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Fix doc generation in CI after merging #233.

Now build doc on PRs too but still deploy only on push to `devel`.