### PR TITLE
Fix tests randomness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ if(ENABLE_CPPCHECK)
         --suppress=unknownMacro:*test/common_tester.h
         --suppress=unknownMacro:*test/ceres/ceres_test_utils.h
         --suppress=constStatement:*examples*
-        --suppress=constStatement:*gtest_misc.cpp:34
-        --suppress=constStatement:*gtest_misc.cpp:42
+        --suppress=constStatement:*gtest_misc.cpp:35
+        --suppress=constStatement:*gtest_misc.cpp:43
         --suppress=unreadVariable:*gtest_se2_ceres_autodiff.cpp:101
         --suppress=unreadVariable:*bundle_sam.cpp:94
         --suppress=unreadVariable:*bundle_sam.cpp:124

--- a/include/manif/autodiff/constants.h
+++ b/include/manif/autodiff/constants.h
@@ -10,24 +10,15 @@ namespace detail {
 namespace manif {
 
 /// @brief Specialize Constants traits for the float-based autodiff::dual type
-template <typename G>
-struct Constants<autodiff::detail::Dual<float, G>> {
-  static const autodiff::detail::Dual<float, G> eps;
+template <typename Scalar, typename G>
+struct Constants<autodiff::detail::Dual<Scalar, G>> {
+  static const autodiff::detail::Dual<Scalar, G> eps;
 };
 
-template <typename G>
-const autodiff::detail::Dual<float, G>
-Constants<autodiff::detail::Dual<float, G>>::eps = autodiff::detail::Dual<float, G>(1e-6);
-
-/// @brief Specialize Constants traits for the double-based autodiff::dual type
-template <typename G>
-struct Constants<autodiff::detail::Dual<double, G>> {
-  static const autodiff::detail::Dual<double, G> eps;
-};
-
-template <typename G>
-const autodiff::detail::Dual<double, G>
-Constants<autodiff::detail::Dual<double, G>>::eps = autodiff::detail::Dual<double, G>(1e-14);
+template <typename Scalar, typename G>
+const autodiff::detail::Dual<Scalar, G>
+Constants<autodiff::detail::Dual<Scalar, G>>::eps =
+  autodiff::detail::Dual<Scalar, G>(Constants<Scalar>::eps);
 
 } // namespace manif
 

--- a/include/manif/ceres/constants.h
+++ b/include/manif/ceres/constants.h
@@ -17,7 +17,8 @@ struct Constants<ceres::Jet<_Scalar, N>>
 
 template <typename _Scalar, int N>
 const ceres::Jet<_Scalar, N>
-Constants<ceres::Jet<_Scalar, N>>::eps = ceres::Jet<_Scalar, N>(1e-14);
+Constants<ceres::Jet<_Scalar, N>>::eps =
+  ceres::Jet<_Scalar, N>(Constants<_Scalar>::eps);
 
 } /* namespace manif */
 

--- a/include/manif/constants.h
+++ b/include/manif/constants.h
@@ -47,7 +47,7 @@ T constexpr csqrt(T x)
 template <typename _Scalar>
 struct Constants
 {
-  static constexpr _Scalar eps      = _Scalar(1e-14);
+  static constexpr _Scalar eps      = std::numeric_limits<_Scalar>::epsilon()*_Scalar(100);
   static constexpr _Scalar eps_sqrt = internal::csqrt(eps);
 
   static constexpr _Scalar to_rad = _Scalar(MANIF_PI / 180.0);
@@ -62,16 +62,6 @@ template <typename _Scalar>
 constexpr _Scalar Constants<_Scalar>::to_rad;
 template <typename _Scalar>
 constexpr _Scalar Constants<_Scalar>::to_deg;
-
-template <>
-struct Constants<float>
-{
-  static constexpr float eps      = float(1e-6);
-  static constexpr float eps_sqrt = internal::csqrt(eps);
-
-  static constexpr float to_rad = float(MANIF_PI / 180.0);
-  static constexpr float to_deg = float(180.0 / MANIF_PI);
-};
 
 } /* namespace manif  */
 

--- a/test/autodiff/gtest_common_tester_autodiff.h
+++ b/test/autodiff/gtest_common_tester_autodiff.h
@@ -19,7 +19,7 @@
 
 #define MANIF_TEST_AUTODIFF(manifold, ad)                                                               \
   using TEST_##manifold##_JACOBIANS_AUTODIFF_##ad##_TESTER = manif::CommonTesterAutodiff<manifold, ad>; \
-  INSTANTIATE_TEST_CASE_P(                                                                              \
+  INSTANTIATE_TEST_SUITE_P(                                                                             \
     TEST_##manifold##_JACOBIANS_AUTODIFF_##ad##_TESTS,                                                  \
     TEST_##manifold##_JACOBIANS_AUTODIFF_##ad##_TESTER,                                                 \
     ::testing::Values(                                                                                  \

--- a/test/autodiff/gtest_common_tester_autodiff.h
+++ b/test/autodiff/gtest_common_tester_autodiff.h
@@ -445,7 +445,7 @@ public:
 
 protected:
   // relax eps for float type
-  Scalar tol_ = (std::is_same<Scalar, float>::value)? 1e-5 : 1e-10;
+  Scalar tol_ = (std::is_same<Scalar, float>::value)? 1e-4 : 1e-8;
 };
 
 } // namespace manif

--- a/test/bundle/gtest_bundle.cpp
+++ b/test/bundle/gtest_bundle.cpp
@@ -203,8 +203,4 @@ MANIF_TEST(GroupA);
 MANIF_TEST_MAP(GroupA);
 MANIF_TEST_JACOBIANS(GroupA);
 
-int main(int argc, char ** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/bundle/gtest_bundle_large.cpp
+++ b/test/bundle/gtest_bundle_large.cpp
@@ -18,8 +18,4 @@ MANIF_TEST_MAP(GroupD);
 MANIF_TEST_JACOBIANS(GroupC);
 MANIF_TEST_JACOBIANS(GroupD);
 
-int main(int argc, char ** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/bundle/gtest_bundle_single_group.cpp
+++ b/test/bundle/gtest_bundle_single_group.cpp
@@ -30,8 +30,4 @@ MANIF_TEST_JACOBIANS(GroupB3);
 MANIF_TEST_JACOBIANS(GroupB4);
 MANIF_TEST_JACOBIANS(GroupB5);
 
-int main(int argc, char ** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -6,7 +6,7 @@
 
 #define MANIF_TEST_JACOBIANS_CERES(manifold)                                                    \
   using TEST_##manifold##_JACOBIANS_CERES_TESTER = JacobianCeresTester<manifold>;               \
-  INSTANTIATE_TEST_CASE_P(                                                                      \
+  INSTANTIATE_TEST_SUITE_P(                                                                     \
     TEST_##manifold##_JACOBIANS_CERES_TESTS,                                                    \
     TEST_##manifold##_JACOBIANS_CERES_TESTER,                                                   \
     ::testing::Values(                                                                          \

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -817,7 +817,7 @@ public:
 
 protected:
 
-  double tol = 1e-12;
+  double tol = 1e-8;
 
   // @todo: Only SE2 Jr_inv fails at this tol...
   // double tol = 1e-14;

--- a/test/ceres/gtest_bundle_ceres.cpp
+++ b/test/ceres/gtest_bundle_ceres.cpp
@@ -13,8 +13,4 @@ using Group = Bundle<double, SO3, R3, SO2, R2>;
 
 MANIF_TEST_JACOBIANS_CERES(Group);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_rn_ceres.cpp
+++ b/test/ceres/gtest_rn_ceres.cpp
@@ -11,8 +11,4 @@ MANIF_TEST_JACOBIANS_CERES(R5d);
 MANIF_TEST_JACOBIANS_CERES(R7d);
 MANIF_TEST_JACOBIANS_CERES(R9d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_se23_ceres.cpp
+++ b/test/ceres/gtest_se23_ceres.cpp
@@ -7,8 +7,4 @@ using namespace manif;
 
 MANIF_TEST_JACOBIANS_CERES(SE_2_3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_se2_ceres.cpp
+++ b/test/ceres/gtest_se2_ceres.cpp
@@ -7,8 +7,4 @@ using namespace manif;
 
 MANIF_TEST_JACOBIANS_CERES(SE2d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_se2_ceres_autodiff.cpp
+++ b/test/ceres/gtest_se2_ceres_autodiff.cpp
@@ -408,8 +408,4 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
   EXPECT_ANGLE_NEAR(-MANIF_PI_2,      state_7.angle(),  ceres_eps);
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_se3_ceres.cpp
+++ b/test/ceres/gtest_se3_ceres.cpp
@@ -7,8 +7,4 @@ using namespace manif;
 
 MANIF_TEST_JACOBIANS_CERES(SE3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_so2_ceres.cpp
+++ b/test/ceres/gtest_so2_ceres.cpp
@@ -325,8 +325,4 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
 
 MANIF_TEST_JACOBIANS_CERES(SO2d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/ceres/gtest_so3_ceres.cpp
+++ b/test/ceres/gtest_so3_ceres.cpp
@@ -7,8 +7,4 @@ using namespace manif;
 
 MANIF_TEST_JACOBIANS_CERES(SO3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -498,7 +498,7 @@ public:
 
       const auto avg_shu = average_biinvariant(mans);
 
-      EXPECT_MANIF_NEAR(avg, avg_shu, (std::is_same<Scalar, float>::value)? 1e-3 : 1e-5);
+      EXPECT_MANIF_NEAR(avg, avg_shu, (std::is_same<Scalar, float>::value)? 1e-2 : 1e-4);
     }
   }
 

--- a/test/common_tester.h
+++ b/test/common_tester.h
@@ -10,7 +10,7 @@
 
 #define MANIF_TEST(manifold)                                              \
   using TEST_##manifold##_TESTER = CommonTester<manifold>;                \
-  INSTANTIATE_TEST_CASE_P(                                                \
+  INSTANTIATE_TEST_SUITE_P(                                               \
     TEST_##manifold##_TESTS,                                              \
     TEST_##manifold##_TESTER,                                             \
     ::testing::Values(                                                    \
@@ -108,7 +108,7 @@
 
 #define MANIF_TEST_JACOBIANS(manifold)                                                                                    \
   using manifold##JacobiansTester = JacobianTester<manifold>;                                                             \
-  INSTANTIATE_TEST_CASE_P(                                                                                                \
+  INSTANTIATE_TEST_SUITE_P(                                                                                               \
     manifold##JacobiansTests,                                                                                             \
     manifold##JacobiansTester,                                                                                            \
     ::testing::Values(                                                                                                    \

--- a/test/gtest_misc.cpp
+++ b/test/gtest_misc.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "manif/manif.h"
+#include "gtest_manif_utils.h"
 #include "gtest_eigen_utils.h"
 
 using namespace manif;
@@ -44,9 +45,4 @@ TEST(TEST_MISC, TEST_SKEWd)
   EXPECT_THROW(skew(s), manif::runtime_error);
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/rn/gtest_rn.cpp
+++ b/test/rn/gtest_rn.cpp
@@ -172,8 +172,4 @@ MANIF_TEST_JACOBIANS(R9d);
 
 #endif
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se2/gtest_se2.cpp
+++ b/test/se2/gtest_se2.cpp
@@ -558,9 +558,4 @@ MANIF_TEST_MAP(SE2d);
 
 MANIF_TEST_JACOBIANS(SE2d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se2/gtest_se2_map.cpp
+++ b/test/se2/gtest_se2_map.cpp
@@ -660,11 +660,4 @@ TEST(TEST_SE2, TEST_SE2_MAP_BETWEEN_JAC)
 }
 */
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-
-//  ::testing::GTEST_FLAG(filter) = "TEST_SE2.TEST_SE2_MAP_INVERSE";
-
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se2/gtest_se2_tangent.cpp
+++ b/test/se2/gtest_se2_tangent.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "manif/SE2.h"
+
+#include "../gtest_manif_utils.h"
 
 using namespace manif;
 
@@ -127,8 +127,4 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_INSTREAM)
   EXPECT_DOUBLE_EQ(3, se2.angle());
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se2/gtest_se2_tangent_map.cpp
+++ b/test/se2/gtest_se2_tangent_map.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "manif/SE2.h"
+
+#include "../gtest_manif_utils.h"
 
 using namespace manif;
 
@@ -113,8 +113,4 @@ TEST(TEST_SE2, TEST_SE2_TANGENT_MAP_RETRACT_JAC)
 //  EXPECT_DOUBLE_EQ(1, J_ret(0));
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se3/gtest_se3.cpp
+++ b/test/se3/gtest_se3.cpp
@@ -1,6 +1,5 @@
-#include <gtest/gtest.h>
-
 #include "manif/SE3.h"
+
 #include "../common_tester.h"
 
 using namespace manif;
@@ -470,8 +469,4 @@ MANIF_TEST_MAP(SE3d);
 
 MANIF_TEST_JACOBIANS(SE3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/se_2_3/gtest_se_2_3.cpp
+++ b/test/se_2_3/gtest_se_2_3.cpp
@@ -376,8 +376,4 @@ MANIF_TEST_MAP(SE_2_3d);
 
 MANIF_TEST_JACOBIANS(SE_2_3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/so2/gtest_so2.cpp
+++ b/test/so2/gtest_so2.cpp
@@ -584,11 +584,4 @@ MANIF_TEST_MAP(SO2d);
 
 MANIF_TEST_JACOBIANS(SO2d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-
-//  ::testing::GTEST_FLAG(filter) = "TEST_SO2.TEST_SO2_LIFT_JAC";
-
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/so2/gtest_so2_map.cpp
+++ b/test/so2/gtest_so2_map.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "manif/SO2.h"
+
+#include "../gtest_manif_utils.h"
 
 using namespace manif;
 
@@ -618,8 +618,5 @@ TEST(TEST_SO2, TEST_SO2_MAP_MINUS_JAC)
   EXPECT_DOUBLE_EQ(-1, J_minus_b(0));
 }
 */
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+
+MANIF_RUN_ALL_TEST;

--- a/test/so2/gtest_so2_tangent.cpp
+++ b/test/so2/gtest_so2_tangent.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "manif/SO2.h"
+
+#include "../gtest_manif_utils.h"
 
 using namespace manif;
 
@@ -128,8 +128,4 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_RETRACT_OPTJAC)
   EXPECT_DOUBLE_EQ(1, J_ret(0));
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/so2/gtest_so2_tangent_map.cpp
+++ b/test/so2/gtest_so2_tangent_map.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "manif/SO2.h"
+
+#include "../gtest_manif_utils.h"
 
 using namespace manif;
 
@@ -98,8 +98,4 @@ TEST(TEST_SO2, TEST_SO2_TANGENT_MAP_RETRACT_JAC)
   EXPECT_DOUBLE_EQ(1, J_ret(0));
 }
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;

--- a/test/so3/gtest_so3.cpp
+++ b/test/so3/gtest_so3.cpp
@@ -631,8 +631,4 @@ MANIF_TEST_MAP(SO3d);
 
 MANIF_TEST_JACOBIANS(SO3d);
 
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+MANIF_RUN_ALL_TEST;


### PR DESCRIPTION
The seed for the random generator is not properly initialized in a whole lot of tests due to the change introduced in #224. This is fixed by using the macro `MANIF_RUN_ALL_TEST` everywhere. Some tests are relaxed as a result.

Moreover, the `Constant` traits is not properly overloaded for the float type. This is fixed calling `std::numeric_limits<Scalar>::epsilon()` (which is then scaled to match the initial order of magnitude of `eps`).