### PR TITLE
Add installation of pip metadata files for when manifpy python bindings are installed only via CMake

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -65,3 +65,22 @@ file(
 install(
   FILES "${MANIFPY_BUILDDIR}/__init__.py"
   DESTINATION ${MANIFPY_INSTDIR})
+  
+# Install pip metadata files to ensure that manif installed via CMake is listed by pip list
+# See https://packaging.python.org/specifications/recording-installed-packages/
+# and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+if (NOT CALL_FROM_SETUP_PY)
+  if (WIN32)
+    set(NEW_LINE "\n\r")
+  else()
+    set(NEW_LINE "\n")
+  endif()
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/METADATA "")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Metadata-Version: 2.1${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Name: manifpy${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${PROJECT_VERSION}${NEW_LINE}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/INSTALLER "cmake${NEW_LINE}")
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/METADATA" "${CMAKE_CURRENT_BINARY_DIR}/INSTALLER"
+    DESTINATION ${PYTHON_PREFIX}/manifpy-${PROJECT_VERSION}.dist-info)
+endif()


### PR DESCRIPTION
Hi @artivis ! 

This PR adds a bit of CMake code to ensure that even if you just install manifpy Python bindings via CMake and adding the correct installation directory to `PYTHONPATH`, the resulting installation is correctly listed by `pip list`.