### PR TITLE
Add missing include in impl/macro.h header

### DIFF
--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -2,6 +2,7 @@
 #define _MANIF_MANIF_FWD_H_
 
 #include <stdexcept> // for std::runtime_error
+#include <utility> // for std::forward
 
 #ifdef NDEBUG
 # ifndef MANIF_NO_DEBUG


### PR DESCRIPTION
`std::forward`  was used in `impl/macro.h` , but the related header `<utility>` was not included.