### PR TITLE
enable tests for autodiff real type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: autodiff/autodiff
-          # ref: main
-          # @todo: see https://github.com/autodiff/autodiff/issues/233
-          ref: refs/tags/v0.6.7
+          ref: main
           path: 'autodiff'
       - name: Setup autodiff
         run: mkdir ${{runner.workspace}}/build_autodiff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ write_basic_package_version_file(
   "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
+  ARCH_INDEPENDENT
 )
 
 # Config

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ local perturbation on the tangent space, many non-linear solvers
 (e.g. with respect to quaternion vector for `SO3`).
 
 For this reason, **manif** is compliant with the auto-differentiation libraries
-[`ceres::Jet`][ceres-jet] and [`autodiff::Dual`][autodiff].
+[`ceres::Jet`][ceres-jet], [`autodiff::Dual`][autodiff] & [`autodiff::Real`][autodiff].
 
 ## Documentation
 

--- a/include/manif/autodiff/constants.h
+++ b/include/manif/autodiff/constants.h
@@ -1,15 +1,21 @@
 #ifndef _MANIF_MANIF_AUTODIFF_CONSTANTS_H_
 #define _MANIF_MANIF_AUTODIFF_CONSTANTS_H_
 
+namespace {
+  // size_t without includes.
+  using size_type = decltype(alignof(char));
+}
+
 namespace autodiff {
 namespace detail {
   template <typename T, typename G> struct Dual;
+  template <size_type N, typename T> class Real;
 } // namespace detail
 } // namespace autodiff
 
 namespace manif {
 
-/// @brief Specialize Constants traits for the float-based autodiff::dual type
+/// @brief Specialize Constants traits for autodiff::Dual type
 template <typename Scalar, typename G>
 struct Constants<autodiff::detail::Dual<Scalar, G>> {
   static const autodiff::detail::Dual<Scalar, G> eps;
@@ -19,6 +25,17 @@ template <typename Scalar, typename G>
 const autodiff::detail::Dual<Scalar, G>
 Constants<autodiff::detail::Dual<Scalar, G>>::eps =
   autodiff::detail::Dual<Scalar, G>(Constants<Scalar>::eps);
+
+/// @brief Specialize Constants traits for autodiff::Real type
+template <size_type N, typename T>
+struct Constants<autodiff::detail::Real<N, T>> {
+  static const autodiff::detail::Real<N, T> eps;
+};
+
+template <size_type N, typename T>
+const autodiff::detail::Real<N, T>
+Constants<autodiff::detail::Real<N, T>>::eps =
+  autodiff::detail::Real<N, T>(Constants<T>::eps);
 
 } // namespace manif
 

--- a/test/autodiff/gtest_common_tester_autodiff.h
+++ b/test/autodiff/gtest_common_tester_autodiff.h
@@ -62,7 +62,7 @@
 
 namespace manif{
   template <typename T> using ddual = autodiff::HigherOrderDual<1, T>;
-  // template <typename T> using rreal = autodiff::Real<1, T>;
+  template <typename T> using rreal = autodiff::Real<1, T>;
   // template <typename T> using vvar = autodiff::Variable<T>;
 }
 
@@ -73,9 +73,8 @@ namespace manif{
 
 #define __MANIF_MAKE_TEST_AUTODIFF_ALL_AD(manifold, type)   \
   __MANIF_MAKE_TEST_AUTODIFF(manifold, type, ddual)         \
+  __MANIF_MAKE_TEST_AUTODIFF(manifold, type, rreal)
 
-  // @todo real seem to have a few issues
-  //__MANIF_MAKE_TEST_AUTODIFF(manifold, type, rreal)
   // @note reverse does not support jacobians atm.
   //__MANIF_MAKE_TEST_AUTODIFF(manifold, type, vvar)
 


### PR DESCRIPTION
These tests can finally be enabled since https://github.com/autodiff/autodiff/issues/185 was fixed.