### PR TITLE
Deprecate windows-2016 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
     strategy:
       matrix:
         combinations: [{
-          "os": "windows-2016",
-          "cmake_generator": "Visual Studio 15 2017"
-         }, {
           "os": "windows-2019",
           "cmake_generator": "Visual Studio 16 2019"
         }, {


### PR DESCRIPTION
  Image has been deprecated https://github.com/actions/virtual-environments/issues/5403