### PR TITLE
replaced ::Constant(0) with ::Zero() due to ceres::Jet compile error

### DIFF
--- a/include/manif/impl/bundle/BundleTangent_base.h
+++ b/include/manif/impl/bundle/BundleTangent_base.h
@@ -366,7 +366,7 @@ struct GeneratorEvaluator<BundleTangentBase<Derived>>
   run(const unsigned int i, intseq<_Idx...>)
   {
     using LieAlg = typename BundleTangentBase<Derived>::LieAlg;
-    LieAlg Ei = LieAlg::Constant(0);
+    LieAlg Ei = LieAlg::Zero();
     // c++11 "fold expression"
     auto l = {((Ei.template block<
       Derived::template Element<_Idx>::LieAlg::RowsAtCompileTime,

--- a/include/manif/impl/rn/RnTangent_base.h
+++ b/include/manif/impl/rn/RnTangent_base.h
@@ -122,7 +122,7 @@ template <typename _Derived>
 typename RnTangentBase<_Derived>::LieAlg
 RnTangentBase<_Derived>::hat() const
 {
-  LieAlg t_hat = LieAlg::Constant(0);
+  LieAlg t_hat = LieAlg::Zero();
   t_hat.template topRightCorner<Dim, 1>() = coeffs();
   return t_hat;
 }
@@ -161,7 +161,7 @@ template <typename _Derived>
 typename RnTangentBase<_Derived>::Jacobian
 RnTangentBase<_Derived>::smallAdj() const
 {
-  static const Jacobian smallAdj = Jacobian::Constant(0);
+  static const Jacobian smallAdj = Jacobian::Zero();
   return smallAdj;
 }
 
@@ -184,7 +184,7 @@ struct GeneratorEvaluator<RnTangentBase<Derived>>
 
     using LieAlg = typename RnTangentBase<Derived>::LieAlg;
 
-    LieAlg Ei = LieAlg::Constant(0);
+    LieAlg Ei = LieAlg::Zero();
 
     Ei(i, RnTangentBase<Derived>::DoF) = 1;
 


### PR DESCRIPTION
I encountered the following compilation error when use the hat operator of the Rn group with ceres:
```
/usr/local/include/manif/impl/rn/RnTangent_base.h:125:34: error: no matching function for call to ‘Eigen::Matrix<ceres::Jet<double, 4>, 4, 4, 0, 4, 4>::Constant(int)’
  125 |   LieAlg t_hat = LieAlg::Constant(0);
```

I fixed this by replacing `::Constant(0)` with `::Zero()`. An alternative fix I think is to use `::Constant(Scalar(0))`. I chose the former because `::Zero()` is much more common in the codebase than `::Constant(Scalar(n))`.

I noticed 3 instances of `::Constant(Scalar(1))` in the code, in the SO2 base and tangent base classes. It would make sense to replace these with `::Ones()` but I have not included that in this pull request.