### PR TITLE
Fixes to the build: set the required C++ standard for tests; add a missing header

### DIFF
--- a/include/manif/impl/eigen.h
+++ b/include/manif/impl/eigen.h
@@ -1,6 +1,8 @@
 #ifndef _MANIF_MANIF_EIGEN_H_
 #define _MANIF_MANIF_EIGEN_H_
 
+#include <cassert>
+
 #include <Eigen/Core>
 #include <Eigen/LU> // for mat.inverse()
 #include <Eigen/Geometry>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,9 +52,9 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 manif_add_gtest(gtest_misc gtest_misc.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   gtest_misc
 )
@@ -104,7 +104,7 @@ else()
   message(STATUS "Could not find autodiff, autodiff tests will not be built.")
 endif()
 
-# Set required C++11 flag
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD 11)
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)
+# Set required C++14 flag
+set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_STANDARD 14)
+set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)

--- a/test/bundle/CMakeLists.txt
+++ b/test/bundle/CMakeLists.txt
@@ -4,9 +4,9 @@ manif_add_gtest(gtest_bundle gtest_bundle.cpp)
 manif_add_gtest(gtest_bundle_single_group gtest_bundle_single_group.cpp)
 manif_add_gtest(gtest_bundle_large gtest_bundle_large.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   gtest_bundle
   gtest_bundle_single_group

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -15,7 +15,7 @@ manif_add_gtest(gtest_se23_ceres gtest_se23_ceres.cpp)
 
 manif_add_gtest(gtest_bundle_ceres gtest_bundle_ceres.cpp)
 
-set(CXX_11_TEST_TARGETS_CERES
+set(CXX_14_TEST_TARGETS_CERES
   # Rn
   gtest_rn_ceres
 
@@ -39,14 +39,14 @@ set(CXX_11_TEST_TARGETS_CERES
   gtest_bundle_ceres
 )
 
-foreach(target ${CXX_11_TEST_TARGETS_CERES})
+foreach(target ${CXX_14_TEST_TARGETS_CERES})
   target_link_libraries(${target} ${CERES_LIBRARIES})
   target_include_directories(${target} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
 endforeach()
 
-set(CXX_11_TEST_TARGETS
-  ${CXX_11_TEST_TARGETS}
-  ${CXX_11_TEST_TARGETS_CERES}
+set(CXX_14_TEST_TARGETS
+  ${CXX_14_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS_CERES}
 
   PARENT_SCOPE
 )

--- a/test/rn/CMakeLists.txt
+++ b/test/rn/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SO3 tests
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  add_definitions(-DMANIF_ARCH_32)
+endif()
+
 manif_add_gtest(gtest_rn gtest_rn.cpp)
 
 set(CXX_14_TEST_TARGETS

--- a/test/rn/CMakeLists.txt
+++ b/test/rn/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_rn gtest_rn.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # R^n
   gtest_rn

--- a/test/rn/gtest_rn.cpp
+++ b/test/rn/gtest_rn.cpp
@@ -14,7 +14,7 @@ using namespace manif;
 // especially, SO3 wasn't an issue despite being Eigen::Vector4d too...
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(R4d)
 
-#ifdef MANIF_COVERAGE_ENABLED
+#if defined(MANIF_COVERAGE_ENABLED) || defined(MANIF_ARCH_32)
 
 MANIF_TEST(R4d);
 MANIF_TEST_JACOBIANS(R4d);
@@ -109,6 +109,7 @@ TEST(TEST_RN, TEST_RN_VEC_ASSIGN_OP)
 }
 
 // This is a little too heavy for coverage and not relevant...
+// The same applies to 32-bit platforms.
 
 MANIF_TEST(R1f);
 MANIF_TEST(R2f);

--- a/test/se2/CMakeLists.txt
+++ b/test/se2/CMakeLists.txt
@@ -5,9 +5,9 @@ manif_add_gtest(gtest_se2_map gtest_se2_map.cpp)
 manif_add_gtest(gtest_se2_tangent gtest_se2_tangent.cpp)
 manif_add_gtest(gtest_se2_tangent_map gtest_se2_tangent_map.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # SE2
   gtest_se2

--- a/test/se3/CMakeLists.txt
+++ b/test/se3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_se3 gtest_se3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # SE3
   gtest_se3

--- a/test/se_2_3/CMakeLists.txt
+++ b/test/se_2_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_se_2_3 gtest_se_2_3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # SE_2_3
   gtest_se_2_3

--- a/test/so2/CMakeLists.txt
+++ b/test/so2/CMakeLists.txt
@@ -12,9 +12,9 @@ manif_add_gtest(gtest_so2_tangent gtest_so2_tangent.cpp)
 # so2 tangent Eigen::Map tests
 manif_add_gtest(gtest_so2_tangent_map gtest_so2_tangent_map.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # SO2
   gtest_so2

--- a/test/so3/CMakeLists.txt
+++ b/test/so3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_so3 gtest_so3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_14_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_14_TEST_TARGETS}
 
   # SO3
   gtest_so3


### PR DESCRIPTION
This fixes two issues:

1. This: https://github.com/artivis/manif/issues/269 (actually fixes instead of discarding or leaving it to an end-user to fix).
2. Numerous errors due to a missing `<cassert>` header, like:

```
In file included from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/lie_group_base.h:6,
                 from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/SO2.h:6,
                 from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/test/so2/gtest_so2.cpp:1:
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/so2/SO2_base.h: In instantiation of 'Eigen::Matrix<typename manif::LieGroupBase<Derived>::Scalar, 2, 1> manif::SO2Base<_Derived>::act(const Eigen::MatrixBase<OtherDerived>&, tl::optional<Eigen::Ref<Eigen::Matrix<typename manif::LieGroupBase<Derived>::Scalar, 2, 1> > >, tl::optional<Eigen::Ref<Eigen::Matrix<typename manif::LieGroupBase<Derived>::Scalar, 2, 2> > >) const [with _EigenDerived = Eigen::Matrix<double, 2, 1>; _Derived = manif::SO2<double>; typename manif::LieGroupBase<Derived>::Scalar = double; typename std::conditional<Eigen::Matrix<typename manif::LieGroupBase<Derived>::Scalar, 2, 1>::IsVectorAtCompileTime, Eigen::InnerStride<1>, Eigen::OuterStride<> >::type = Eigen::InnerStride<1>; typename std::conditional<Eigen::Matrix<typename manif::LieGroupBase<Derived>::Scalar, 2, 2>::IsVectorAtCompileTime, Eigen::InnerStride<1>, Eigen::OuterStride<> >::type = Eigen::OuterStride<>]':
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/test/so2/gtest_so2.cpp:509:35:   required from here
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/eigen.h:94:9: error: 'assert' was not declared in this scope
   94 |   assert(x.cols() == 1 && "Expected a vector !"); \
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/eigen.h:97:3: note: in expansion of macro 'assert_is_vector'
   97 |   assert_is_vector(x); \
      |   ^~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/so2/SO2_base.h:243:3: note: in expansion of macro 'assert_vector_dim'
  243 |   assert_vector_dim(v, 2);
      |   ^~~~~~~~~~~~~~~~~
In file included from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/SO2.h:10:
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/so2/SO2_base.h:1:1: note: 'assert' is defined in header '<cassert>'; did you forget to '#include <cassert>'?
  +++ |+#include <cassert>
    1 | #ifndef _MANIF_MANIF_SO2_BASE_H_
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/eigen.h:64:9: error: 'assert' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
   64 |   assert(x.rows() == dim && "x.rows != "#dim" .");
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/manif-bb3f6758ae467b7f24def71861798d131f157032/include/manif/impl/eigen.h:98:3: note: in expansion of macro 'assert_rows_dim'
   98 |   assert_rows_dim(x, dim);
      |   ^~~~~~~~~~~~~~~
```