### PR TITLE
Set test target default cxx standard iif no glob set

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,9 +52,9 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 manif_add_gtest(gtest_misc gtest_misc.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   gtest_misc
 )
@@ -104,7 +104,9 @@ else()
   message(STATUS "Could not find autodiff, autodiff tests will not be built.")
 endif()
 
-# Set required C++11 flag
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD 11)
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  # Set required C++11 flag
+  set_property(TARGET ${CXX_TEST_TARGETS} PROPERTY CXX_STANDARD 11)
+endif()
+set_property(TARGET ${CXX_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET ${CXX_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)

--- a/test/bundle/CMakeLists.txt
+++ b/test/bundle/CMakeLists.txt
@@ -4,9 +4,9 @@ manif_add_gtest(gtest_bundle gtest_bundle.cpp)
 manif_add_gtest(gtest_bundle_single_group gtest_bundle_single_group.cpp)
 manif_add_gtest(gtest_bundle_large gtest_bundle_large.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   gtest_bundle
   gtest_bundle_single_group

--- a/test/ceres/CMakeLists.txt
+++ b/test/ceres/CMakeLists.txt
@@ -15,7 +15,7 @@ manif_add_gtest(gtest_se23_ceres gtest_se23_ceres.cpp)
 
 manif_add_gtest(gtest_bundle_ceres gtest_bundle_ceres.cpp)
 
-set(CXX_11_TEST_TARGETS_CERES
+set(CXX_TEST_TARGETS_CERES
   # Rn
   gtest_rn_ceres
 
@@ -39,14 +39,14 @@ set(CXX_11_TEST_TARGETS_CERES
   gtest_bundle_ceres
 )
 
-foreach(target ${CXX_11_TEST_TARGETS_CERES})
+foreach(target ${CXX_TEST_TARGETS_CERES})
   target_link_libraries(${target} ${CERES_LIBRARIES})
   target_include_directories(${target} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
 endforeach()
 
-set(CXX_11_TEST_TARGETS
-  ${CXX_11_TEST_TARGETS}
-  ${CXX_11_TEST_TARGETS_CERES}
+set(CXX_TEST_TARGETS
+  ${CXX_TEST_TARGETS}
+  ${CXX_TEST_TARGETS_CERES}
 
   PARENT_SCOPE
 )

--- a/test/rn/CMakeLists.txt
+++ b/test/rn/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_rn gtest_rn.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # R^n
   gtest_rn

--- a/test/se2/CMakeLists.txt
+++ b/test/se2/CMakeLists.txt
@@ -5,9 +5,9 @@ manif_add_gtest(gtest_se2_map gtest_se2_map.cpp)
 manif_add_gtest(gtest_se2_tangent gtest_se2_tangent.cpp)
 manif_add_gtest(gtest_se2_tangent_map gtest_se2_tangent_map.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # SE2
   gtest_se2

--- a/test/se3/CMakeLists.txt
+++ b/test/se3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_se3 gtest_se3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # SE3
   gtest_se3

--- a/test/se_2_3/CMakeLists.txt
+++ b/test/se_2_3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_se_2_3 gtest_se_2_3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # SE_2_3
   gtest_se_2_3

--- a/test/so2/CMakeLists.txt
+++ b/test/so2/CMakeLists.txt
@@ -12,9 +12,9 @@ manif_add_gtest(gtest_so2_tangent gtest_so2_tangent.cpp)
 # so2 tangent Eigen::Map tests
 manif_add_gtest(gtest_so2_tangent_map gtest_so2_tangent_map.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # SO2
   gtest_so2

--- a/test/so3/CMakeLists.txt
+++ b/test/so3/CMakeLists.txt
@@ -2,9 +2,9 @@
 
 manif_add_gtest(gtest_so3 gtest_so3.cpp)
 
-set(CXX_11_TEST_TARGETS
+set(CXX_TEST_TARGETS
 
-  ${CXX_11_TEST_TARGETS}
+  ${CXX_TEST_TARGETS}
 
   # SO3
   gtest_so3


### PR DESCRIPTION
Set test targets default CXX standards iif no global standard is set by the user with e.g., `CMAKE_CXX_STANDARD` in the toolchain or `cmake -DCMAKE_CXX_STANDARD=xx` in the command line.

Replaces #277 