### PR TITLE
Update ceres::LocalParameterization to ceres::Manifold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         build_type: [Release, Debug]
         compiler: [
           {
@@ -193,7 +193,13 @@ jobs:
 
   ceres:
     needs: [build-ubuntu]
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # Test for both Ceres pre/post 2.2
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Xcode 10.3 & Xcode 12.2
-        # removing macos-11.0 for now, see
-        #https://github.com/actions/virtual-environments/issues/841
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13, macos-14]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-latest, ubuntu-latest] #windows-latest,
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.12']
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -293,7 +293,7 @@ jobs:
     needs: [build-ubuntu, build-mac]
     strategy:
       matrix:
-        platform: [ubuntu-20.04, ubuntu-latest]
+        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -322,21 +322,3 @@ jobs:
         run: sudo make install
       - name: Test Import
         run: python3 -c 'import manifpy'
-
-  # arm64:
-  #   needs: [build-ubuntu]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #     - name: Setup
-  #       run: mkdir ${{runner.workspace}}/build
-  #     - name: Configure CMake
-  #       working-directory: ${{runner.workspace}}/build
-  #       run: cmake $GITHUB_WORKSPACE -DENABLE_COVERAGE=ON -DBUILD_TESTING=ON
-  #     - name: Build
-  #       working-directory: ${{runner.workspace}}/build
-  #       run: make
-  #     - name: Test
-  #       working-directory: ${{runner.workspace}}/build
-  #       run: make test

--- a/docs/pages/cpp/On-the-use-with-Ceres.md
+++ b/docs/pages/cpp/On-the-use-with-Ceres.md
@@ -94,8 +94,8 @@ ceres::Problem problem(problem_options);
 problem->AddParameterBlock(my_state.data(), 4);
 
 // Associate a LocalParameterization to the state vector
-problem_->SetParameterization(my_state.data(),
-                              new EigenQuaternionParameterization() );
+problem_->SetManifold(my_state.data(),
+                      new EigenQuaternionParameterization() );
 ```
 
 The `LocalParameterization` class (and derived) performs the state update step
@@ -221,8 +221,8 @@ std::shared_ptr<ceres::Manifold>
   auto_diff_manifold =
     manif::make_manifold_autodiff<SE2d>();
 
-problem.SetParameterization( average_state.data(),
-                             auto_diff_manifold.get() );
+problem.SetManifold( average_state.data(),
+                     auto_diff_manifold.get() );
 
 // Run the solver!
 ceres::Solver::Options options;

--- a/docs/pages/cpp/On-the-use-with-Ceres.md
+++ b/docs/pages/cpp/On-the-use-with-Ceres.md
@@ -179,7 +179,7 @@ In this example, we compute an average point from 4 points in `SE2`.
 // Tell ceres not to take ownership of the raw pointers
 ceres::Problem::Options problem_options;
 problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
 
 ceres::Problem problem(problem_options);
 
@@ -217,12 +217,12 @@ problem.AddResidualBlock( obj_3_pi_over_4.get(),
 // We use a second manif helper that creates a ceres local parameterization
 // for our optimized state block.
 
-std::shared_ptr<ceres::LocalParameterization>
-  auto_diff_local_parameterization =
-    manif::make_local_parametrization_autodiff<SE2d>();
+std::shared_ptr<ceres::Manifold>
+  auto_diff_manifold =
+    manif::make_manifold_autodiff<SE2d>();
 
 problem.SetParameterization( average_state.data(),
-                             auto_diff_local_parameterization.get() );
+                             auto_diff_manifold.get() );
 
 // Run the solver!
 ceres::Solver::Options options;

--- a/include/manif/ceres/ceres.h
+++ b/include/manif/ceres/ceres.h
@@ -3,7 +3,11 @@
 
 #include "manif/ceres/constants.h"
 #include "manif/ceres/constraint.h"
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 #include "manif/ceres/manifold.h"
+#else
+#include "manif/ceres/local_parametrization.h"
+#endif
 #include "manif/ceres/objective.h"
 #include "manif/ceres/ceres_utils.h"
 
@@ -18,7 +22,11 @@ struct is_ad<ceres::Jet<_Scalar, _N>> : std::integral_constant<bool, true> { };
 
 #ifdef _MANIF_MANIF_SO2_H_
 using CeresConstraintSO2 = CeresConstraintFunctor<SO2d>;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 using CeresManifoldSO2 = CeresManifoldFunctor<SO2d>;
+#else
+using CeresLocalParameterizationSO2 = CeresLocalParameterizationFunctor<SO2d>;
+#endif
 using CeresObjectiveSO2 = CeresObjectiveFunctor<SO2d>;
 #else
 using CeresConstraintSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
@@ -28,7 +36,11 @@ using CeresObjectiveSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_H
 
 #ifdef _MANIF_MANIF_SO3_H_
 using CeresConstraintSO3 = CeresConstraintFunctor<SO3d>;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 using CeresManifoldSO3 = CeresManifoldFunctor<SO3d>;
+#else
+using CeresLocalParameterizationSO3 = CeresLocalParameterizationFunctor<SO3d>;
+#endif
 using CeresObjectiveSO3 = CeresObjectiveFunctor<SO3d>;
 #else
 using CeresConstraintSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
@@ -38,7 +50,11 @@ using CeresObjectiveSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_H
 
 #ifdef _MANIF_MANIF_SE2_H_
 using CeresConstraintSE2 = CeresConstraintFunctor<SE2d>;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 using CeresManifoldSE2 = CeresManifoldFunctor<SE2d>;
+#else
+using CeresLocalParameterizationSE2 = CeresLocalParameterizationFunctor<SE2d>;
+#endif
 using CeresObjectiveSE2 = CeresObjectiveFunctor<SE2d>;
 #else
 using CeresConstraintSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
@@ -48,7 +64,11 @@ using CeresObjectiveSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_H
 
 #ifdef _MANIF_MANIF_SE3_H_
 using CeresConstraintSE3 = CeresConstraintFunctor<SE3d>;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 using CeresManifoldSE3 = CeresManifoldFunctor<SE3d>;
+#else
+using CeresLocalParameterizationSE3 = CeresLocalParameterizationFunctor<SE3d>;
+#endif
 using CeresObjectiveSE3 = CeresObjectiveFunctor<SE3d>;
 #else
 using CeresConstraintSE3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;

--- a/include/manif/ceres/ceres.h
+++ b/include/manif/ceres/ceres.h
@@ -3,7 +3,7 @@
 
 #include "manif/ceres/constants.h"
 #include "manif/ceres/constraint.h"
-#include "manif/ceres/local_parametrization.h"
+#include "manif/ceres/manifold.h"
 #include "manif/ceres/objective.h"
 #include "manif/ceres/ceres_utils.h"
 
@@ -18,41 +18,41 @@ struct is_ad<ceres::Jet<_Scalar, _N>> : std::integral_constant<bool, true> { };
 
 #ifdef _MANIF_MANIF_SO2_H_
 using CeresConstraintSO2 = CeresConstraintFunctor<SO2d>;
-using CeresLocalParameterizationSO2 = CeresLocalParameterizationFunctor<SO2d>;
+using CeresManifoldSO2 = CeresManifoldFunctor<SO2d>;
 using CeresObjectiveSO2 = CeresObjectiveFunctor<SO2d>;
 #else
 using CeresConstraintSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
-using CeresLocalParameterizationSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
+using CeresManifoldSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 using CeresObjectiveSO2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 #endif
 
 #ifdef _MANIF_MANIF_SO3_H_
 using CeresConstraintSO3 = CeresConstraintFunctor<SO3d>;
-using CeresLocalParameterizationSO3 = CeresLocalParameterizationFunctor<SO3d>;
+using CeresManifoldSO3 = CeresManifoldFunctor<SO3d>;
 using CeresObjectiveSO3 = CeresObjectiveFunctor<SO3d>;
 #else
 using CeresConstraintSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
-using CeresLocalParameterizationSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
+using CeresManifoldSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 using CeresObjectiveSO3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 #endif
 
 #ifdef _MANIF_MANIF_SE2_H_
 using CeresConstraintSE2 = CeresConstraintFunctor<SE2d>;
-using CeresLocalParameterizationSE2 = CeresLocalParameterizationFunctor<SE2d>;
+using CeresManifoldSE2 = CeresManifoldFunctor<SE2d>;
 using CeresObjectiveSE2 = CeresObjectiveFunctor<SE2d>;
 #else
 using CeresConstraintSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
-using CeresLocalParameterizationSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
+using CeresManifoldSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 using CeresObjectiveSE2 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 #endif
 
 #ifdef _MANIF_MANIF_SE3_H_
 using CeresConstraintSE3 = CeresConstraintFunctor<SE3d>;
-using CeresLocalParameterizationSE3 = CeresLocalParameterizationFunctor<SE3d>;
+using CeresManifoldSE3 = CeresManifoldFunctor<SE3d>;
 using CeresObjectiveSE3 = CeresObjectiveFunctor<SE3d>;
 #else
 using CeresConstraintSE3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
-using CeresLocalParameterizationSE3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
+using CeresManifoldSE3 = internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 using CeresObjectiveSE3= internal::YOU_MUST_INCLUDE_MANIF_BEFORE_CERES_HELPER_HEADERS;
 #endif
 

--- a/include/manif/ceres/ceres_utils.h
+++ b/include/manif/ceres/ceres_utils.h
@@ -1,28 +1,28 @@
 #ifndef _MANIF_MANIF_CERES_UTILS_H_
 #define _MANIF_MANIF_CERES_UTILS_H_
 
-#include "manif/ceres/local_parametrization.h"
+#include "manif/ceres/manifold.h"
 #include "manif/ceres/objective.h"
 #include "manif/ceres/constraint.h"
 
-#include <ceres/autodiff_local_parameterization.h>
+#include <ceres/autodiff_manifold.h>
 #include <ceres/autodiff_cost_function.h>
 
 namespace manif {
 
 /**
  * @brief Helper function to create a Ceres autodiff local parameterization wrapper.
- * @see CeresLocalParameterizationFunctor
+ * @see CeresManifoldFunctor
  */
 template <typename _LieGroup>
 std::shared_ptr<
-  ceres::AutoDiffLocalParameterization<CeresLocalParameterizationFunctor<_LieGroup>,
+  ceres::AutoDiffManifold<CeresManifoldFunctor<_LieGroup>,
   _LieGroup::RepSize, _LieGroup::DoF>>
-make_local_parameterization_autodiff()
+make_manifold_autodiff()
 {
   return std::make_shared<
-      ceres::AutoDiffLocalParameterization<
-        CeresLocalParameterizationFunctor<_LieGroup>, _LieGroup::RepSize, _LieGroup::DoF>>();
+      ceres::AutoDiffManifold<
+        CeresManifoldFunctor<_LieGroup>, _LieGroup::RepSize, _LieGroup::DoF>>();
 }
 
 /**

--- a/include/manif/ceres/ceres_utils.h
+++ b/include/manif/ceres/ceres_utils.h
@@ -1,17 +1,26 @@
 #ifndef _MANIF_MANIF_CERES_UTILS_H_
 #define _MANIF_MANIF_CERES_UTILS_H_
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 #include "manif/ceres/manifold.h"
+#else
+#include "manif/ceres/local_parametrization.h"
+#endif
 #include "manif/ceres/objective.h"
 #include "manif/ceres/constraint.h"
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 #include <ceres/autodiff_manifold.h>
+#else
+#include <ceres/autodiff_local_parameterization.h>
+#endif
 #include <ceres/autodiff_cost_function.h>
 
 namespace manif {
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 /**
- * @brief Helper function to create a Ceres autodiff local parameterization wrapper.
+ * @brief Helper function to create a Ceres Manifold parameterization wrapper.
  * @see CeresManifoldFunctor
  */
 template <typename _LieGroup>
@@ -24,6 +33,22 @@ make_manifold_autodiff()
       ceres::AutoDiffManifold<
         CeresManifoldFunctor<_LieGroup>, _LieGroup::RepSize, _LieGroup::DoF>>();
 }
+#else
+/**
+ * @brief Helper function to create a Ceres autodiff local parameterization wrapper.
+ * @see CeresLocalParameterizationFunctor
+ */
+template <typename _LieGroup>
+std::shared_ptr<
+  ceres::AutoDiffLocalParameterization<CeresLocalParameterizationFunctor<_LieGroup>,
+  _LieGroup::RepSize, _LieGroup::DoF>>
+make_local_parameterization_autodiff()
+{
+  return std::make_shared<
+      ceres::AutoDiffLocalParameterization<
+        CeresLocalParameterizationFunctor<_LieGroup>, _LieGroup::RepSize, _LieGroup::DoF>>();
+}
+#endif
 
 /**
  * @brief Helper function to create a Ceres autodiff objective wrapper.

--- a/include/manif/ceres/constants.h
+++ b/include/manif/ceres/constants.h
@@ -4,6 +4,7 @@
 #include "manif/constants.h"
 
 #include <ceres/jet.h>
+#include <ceres/version.h>
 
 namespace manif {
 

--- a/include/manif/ceres/local_parametrization.h
+++ b/include/manif/ceres/local_parametrization.h
@@ -1,0 +1,46 @@
+#ifndef _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_
+#define _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_
+
+#include <Eigen/Core>
+
+namespace manif {
+
+/**
+ * @brief A wrapper for Ceres autodiff local parameterization.
+ */
+template <typename _LieGroup>
+class CeresLocalParameterizationFunctor
+{
+  using LieGroup = _LieGroup;
+  using Tangent  = typename _LieGroup::Tangent;
+
+  template <typename _Scalar>
+  using LieGroupTemplate = typename LieGroup::template LieGroupTemplate<_Scalar>;
+
+  template <typename _Scalar>
+  using TangentTemplate = typename Tangent::template TangentTemplate<_Scalar>;
+
+public:
+
+  CeresLocalParameterizationFunctor() = default;
+  virtual ~CeresLocalParameterizationFunctor() = default;
+
+  template<typename T>
+  bool operator()(const T* state_raw,
+                  const T* delta_raw,
+                  T* state_plus_delta_raw) const
+  {
+    const Eigen::Map<const LieGroupTemplate<T>> state(state_raw);
+    const Eigen::Map<const TangentTemplate<T>>  delta(delta_raw);
+
+    Eigen::Map<LieGroupTemplate<T>> state_plus_delta(state_plus_delta_raw);
+
+    state_plus_delta = state + delta;
+
+    return true;
+  }
+};
+
+} /* namespace manif */
+
+#endif /* _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_ */

--- a/include/manif/ceres/manifold.h
+++ b/include/manif/ceres/manifold.h
@@ -1,5 +1,5 @@
-#ifndef _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_
-#define _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_
+#ifndef _MANIF_MANIF_CERES_MANIFOLD_H_
+#define _MANIF_MANIF_CERES_MANIFOLD_H_
 
 #include <Eigen/Core>
 
@@ -9,7 +9,7 @@ namespace manif {
  * @brief A wrapper for Ceres autodiff local parameterization.
  */
 template <typename _LieGroup>
-class CeresLocalParameterizationFunctor
+class CeresManifoldFunctor
 {
   using LieGroup = _LieGroup;
   using Tangent  = typename _LieGroup::Tangent;
@@ -22,8 +22,8 @@ class CeresLocalParameterizationFunctor
 
 public:
 
-  CeresLocalParameterizationFunctor() = default;
-  virtual ~CeresLocalParameterizationFunctor() = default;
+  CeresManifoldFunctor() = default;
+  virtual ~CeresManifoldFunctor() = default;
 
   template<typename T>
   bool operator()(const T* state_raw,
@@ -43,4 +43,4 @@ public:
 
 } /* namespace manif */
 
-#endif /* _MANIF_MANIF_CERES_LOCAL_PARAMETRIZATION_H_ */
+#endif /* _MANIF_MANIF_CERES_MANIFOLD_H_ */

--- a/include/manif/ceres/manifold.h
+++ b/include/manif/ceres/manifold.h
@@ -25,9 +25,10 @@ public:
   CeresManifoldFunctor() = default;
   virtual ~CeresManifoldFunctor() = default;
 
-  bool Plus(const double* state_raw,
-            const double* delta_raw,
-            double* state_plus_delta_raw) const
+  template <typename T>
+  bool Plus(const T* state_raw,
+            const T* delta_raw,
+            T* state_plus_delta_raw) const
   {
     const Eigen::Map<const LieGroupTemplate<T>> state(state_raw);
     const Eigen::Map<const TangentTemplate<T>>  delta(delta_raw);
@@ -39,9 +40,10 @@ public:
     return true;
   }
 
-  bool Minus(const double* y_raw,
-             const double* x_raw,
-             double* y_minus_x_raw) const
+  template <typename T>
+  bool Minus(const T* y_raw,
+             const T* x_raw,
+             T* y_minus_x_raw) const
   {
     const Eigen::Map<const LieGroupTemplate<T>> y(y_raw);
     const Eigen::Map<const TangentTemplate<T>>  x(x_raw);

--- a/include/manif/ceres/manifold.h
+++ b/include/manif/ceres/manifold.h
@@ -46,9 +46,9 @@ public:
              T* y_minus_x_raw) const
   {
     const Eigen::Map<const LieGroupTemplate<T>> y(y_raw);
-    const Eigen::Map<const TangentTemplate<T>>  x(x_raw);
+    const Eigen::Map<const LieGroupTemplate<T>>  x(x_raw);
 
-    Eigen::Map<LieGroupTemplate<T>> y_minus_x(y_minus_x_raw);
+    Eigen::Map<TangentTemplate<T>> y_minus_x(y_minus_x_raw);
 
     y_minus_x = y - x;
 

--- a/include/manif/ceres/manifold.h
+++ b/include/manif/ceres/manifold.h
@@ -25,10 +25,9 @@ public:
   CeresManifoldFunctor() = default;
   virtual ~CeresManifoldFunctor() = default;
 
-  template<typename T>
-  bool operator()(const T* state_raw,
-                  const T* delta_raw,
-                  T* state_plus_delta_raw) const
+  bool Plus(const double* state_raw,
+            const double* delta_raw,
+            double* state_plus_delta_raw) const
   {
     const Eigen::Map<const LieGroupTemplate<T>> state(state_raw);
     const Eigen::Map<const TangentTemplate<T>>  delta(delta_raw);
@@ -36,6 +35,20 @@ public:
     Eigen::Map<LieGroupTemplate<T>> state_plus_delta(state_plus_delta_raw);
 
     state_plus_delta = state + delta;
+
+    return true;
+  }
+
+  bool Minus(const double* y_raw,
+             const double* x_raw,
+             double* y_minus_x_raw) const
+  {
+    const Eigen::Map<const LieGroupTemplate<T>> y(y_raw);
+    const Eigen::Map<const TangentTemplate<T>>  x(x_raw);
+
+    Eigen::Map<LieGroupTemplate<T>> y_minus_x(y_minus_x_raw);
+
+    y_minus_x = y - x;
 
     return true;
   }

--- a/include/manif/impl/se3/SE3.h
+++ b/include/manif/impl/se3/SE3.h
@@ -154,12 +154,17 @@ SE3<_Scalar>::SE3(const LieGroupBase<_DerivedOther>& o)
   //
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+// Temporarily disable this warning which causes false positive with GCC 12
+// See e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247
 template <typename _Scalar>
 SE3<_Scalar>::SE3(const Translation& t, const Eigen::Quaternion<Scalar>& q)
   : SE3((DataType() << t, q.coeffs() ).finished())
 {
   //
 }
+#pragma GCC diagnostic pop
 
 template <typename _Scalar>
 SE3<_Scalar>::SE3(const Translation& t, const Eigen::AngleAxis<Scalar>& a)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_package(GTest QUIET)
 

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -450,7 +450,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().inverse(), state_out);
 
-    manifold->ComputeJacobian(state_raw, adJ_locpar.data());
+    manifold->PlusJacobian(state_raw, adJ_locpar.data());
 
     // Compute the local_de-parameterization (?) Jac
     parameters = new double*[2];
@@ -488,7 +488,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().log(J_out_s), delta_out);
 
-    manifold->ComputeJacobian(state_raw, adJ_locpar.data());
+    manifold->PlusJacobian(state_raw, adJ_locpar.data());
 
     adJ_out_s = ad_r_J_out_spd * adJ_locpar;
 
@@ -513,7 +513,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().rplus(getDelta(), J_out_s, J_out_so), state_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -532,7 +532,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -562,7 +562,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().lplus(getDelta(), J_out_s, J_out_so), state_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -581,7 +581,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -614,13 +614,13 @@ public:
 
     EXPECT_MANIF_NEAR(getState().rminus(getStateOther()), delta_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
     adJ_out_s = adJ_out_R * lhs_adJ_locpar;
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -656,13 +656,13 @@ public:
 
     EXPECT_MANIF_NEAR(getState().lminus(getStateOther()), delta_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
     adJ_out_s = adJ_out_R * lhs_adJ_locpar;
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -694,7 +694,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().compose(getStateOther(), J_out_s, J_out_so), state_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -713,7 +713,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -742,7 +742,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().between(getStateOther(), J_out_s, J_out_so), state_out);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -761,7 +761,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -801,7 +801,7 @@ public:
     Eigen::Matrix<double, LieGroup::Dim, LieGroup::Dim> J_vout_v;
     EXPECT_EIGEN_NEAR(getState().act(vin, J_vout_s, J_vout_v), vout, tol);
 
-    manifold->ComputeJacobian(
+    manifold->PlusJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 

--- a/test/ceres/ceres_test_utils.h
+++ b/test/ceres/ceres_test_utils.h
@@ -378,9 +378,9 @@ class JacobianCeresTester
   using Jacobian  = typename LieGroup::Jacobian;
 
   using ManifObjective = CeresObjectiveFunctor<LieGroup>;
-  using ManifLocalParameterization = CeresLocalParameterizationFunctor<LieGroup>;
+  using ManifManifold = CeresManifoldFunctor<LieGroup>;
 
-  using LocalParamJacobian =
+  using ManifoldJacobian =
     Eigen::Matrix<typename LieGroup::Scalar,
                   LieGroup::RepSize,
                   LieGroup::DoF,
@@ -388,7 +388,7 @@ class JacobianCeresTester
                     Eigen::RowMajor:
                     Eigen::ColMajor>;
 
-  using LocalParameterizationPtr = std::shared_ptr<ceres::LocalParameterization>;
+  using ManifoldPtr = std::shared_ptr<ceres::Manifold>;
 
   using Inverse = CeresInverseFunctor<LieGroup>;
   using Rplus = CeresRplusFunctor<LieGroup>;
@@ -450,7 +450,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().inverse(), state_out);
 
-    local_parameterization->ComputeJacobian(state_raw, adJ_locpar.data());
+    manifold->ComputeJacobian(state_raw, adJ_locpar.data());
 
     // Compute the local_de-parameterization (?) Jac
     parameters = new double*[2];
@@ -488,7 +488,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().log(J_out_s), delta_out);
 
-    local_parameterization->ComputeJacobian(state_raw, adJ_locpar.data());
+    manifold->ComputeJacobian(state_raw, adJ_locpar.data());
 
     adJ_out_s = ad_r_J_out_spd * adJ_locpar;
 
@@ -513,7 +513,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().rplus(getDelta(), J_out_s, J_out_so), state_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -532,7 +532,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -562,7 +562,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().lplus(getDelta(), J_out_s, J_out_so), state_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -581,7 +581,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -614,13 +614,13 @@ public:
 
     EXPECT_MANIF_NEAR(getState().rminus(getStateOther()), delta_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
     adJ_out_s = adJ_out_R * lhs_adJ_locpar;
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -656,13 +656,13 @@ public:
 
     EXPECT_MANIF_NEAR(getState().lminus(getStateOther()), delta_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
     adJ_out_s = adJ_out_R * lhs_adJ_locpar;
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -694,7 +694,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().compose(getStateOther(), J_out_s, J_out_so), state_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -713,7 +713,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -742,7 +742,7 @@ public:
 
     EXPECT_MANIF_NEAR(getState().between(getStateOther(), J_out_s, J_out_so), state_out);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -761,7 +761,7 @@ public:
 
     EXPECT_EIGEN_NEAR(J_out_s, adJ_out_s, tol);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_other_raw, rhs_adJ_locpar.data()
     );
 
@@ -801,7 +801,7 @@ public:
     Eigen::Matrix<double, LieGroup::Dim, LieGroup::Dim> J_vout_v;
     EXPECT_EIGEN_NEAR(getState().act(vin, J_vout_s, J_vout_v), vout, tol);
 
-    local_parameterization->ComputeJacobian(
+    manifold->ComputeJacobian(
       state_raw, lhs_adJ_locpar.data()
     );
 
@@ -829,8 +829,8 @@ protected:
 
   double **jacobians;
 
-  LocalParameterizationPtr local_parameterization =
-    make_local_parameterization_autodiff<LieGroup>();
+  ManifoldPtr manifold =
+    make_manifold_autodiff<LieGroup>();
 
   LieGroup state_out;
 
@@ -839,7 +839,7 @@ protected:
   Jacobian J_out_s, J_out_so,
            adJ_out_s, adJ_out_so;
 
-  LocalParamJacobian adJ_locpar, lhs_adJ_locpar, rhs_adJ_locpar;
+  ManifoldJacobian adJ_locpar, lhs_adJ_locpar, rhs_adJ_locpar;
 };
 
 } // namespace manif

--- a/test/ceres/gtest_se2_ceres_autodiff.cpp
+++ b/test/ceres/gtest_se2_ceres_autodiff.cpp
@@ -11,7 +11,11 @@
 
 namespace manif {
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
 using ManifoldSE2 = CeresManifoldSE2;
+#else
+using ManifoldSE2 = CeresLocalParameterizationSE2;
+#endif
 using ObjectiveSE2  = CeresObjectiveSE2;
 using ConstraintSE2 = CeresConstraintSE2;
 
@@ -74,9 +78,13 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_OBJECTIVE_AUTODIFF)
 
 TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
 {
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
-    auto_diff_manifold =
-      make_manifold_autodiff<SE2d>();
+    auto_diff_manifold = make_manifold_autodiff<SE2d>();
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_manifold = make_local_parameterization_autodiff<SE2d>();
+#endif
 
   // 0 + pi
 
@@ -120,7 +128,12 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SE2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[SE2d::RepSize*SE2Tangentd::RepSize];
+
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
+  auto_diff_manifold->PlusJacobian(x, J_rplus);
+#else
   auto_diff_manifold->ComputeJacobian(x, J_rplus);
+#endif
 
   /// @todo values copied from terminal...
   EXPECT_DOUBLE_EQ( 0.70710678118654746, J_rplus[0]);
@@ -142,7 +155,11 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#else
+    problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#endif
 
   ceres::Problem problem(problem_options);
 
@@ -180,12 +197,19 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
                             nullptr,
                             average_state.data() );
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
-    auto_diff_manifold =
-      make_manifold_autodiff<SE2d>();
+    auto_diff_manifold = make_manifold_autodiff<SE2d>();
 
   problem.SetManifold( average_state.data(),
                        auto_diff_manifold.get() );
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_local_parameterization = make_local_parameterization_autodiff<SE2d>();
+
+  problem.SetParameterization( average_state.data(),
+                               auto_diff_local_parameterization.get() );
+#endif
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -223,7 +247,11 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#else
+  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#endif
 
   //
   //    5 ____ 4
@@ -318,9 +346,9 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
                             nullptr,
                             state_0.data() );
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
-    auto_diff_manifold =
-      make_manifold_autodiff<SE2d>();
+    auto_diff_manifold = make_manifold_autodiff<SE2d>();
 
   problem.SetManifold( state_0.data(),
                        auto_diff_manifold.get() );
@@ -345,6 +373,42 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
 
   problem.SetManifold( state_7.data(),
                        auto_diff_manifold.get() );
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_local_parameterization = make_local_parameterization_autodiff<SE2d>();
+
+  problem.SetParameterization(
+    state_0.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_1.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_2.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_3.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_4.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_5.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_6.data(), auto_diff_local_parameterization.get()
+  );
+
+  problem.SetParameterization(
+    state_7.data(), auto_diff_local_parameterization.get()
+  );
+#endif
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/ceres/gtest_se2_ceres_autodiff.cpp
+++ b/test/ceres/gtest_se2_ceres_autodiff.cpp
@@ -184,8 +184,8 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
     auto_diff_manifold =
       make_manifold_autodiff<SE2d>();
 
-  problem.SetParameterization( average_state.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( average_state.data(),
+                       auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -322,29 +322,29 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
     auto_diff_manifold =
       make_manifold_autodiff<SE2d>();
 
-  problem.SetParameterization( state_0.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_0.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_1.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_1.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_2.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_2.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_3.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_3.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_4.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_4.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_5.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_5.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_6.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_6.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_7.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_7.data(),
+                       auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/ceres/gtest_se2_ceres_autodiff.cpp
+++ b/test/ceres/gtest_se2_ceres_autodiff.cpp
@@ -11,7 +11,7 @@
 
 namespace manif {
 
-using LocalParameterizationSE2 = CeresLocalParameterizationSE2;
+using ManifoldSE2 = CeresManifoldSE2;
 using ObjectiveSE2  = CeresObjectiveSE2;
 using ConstraintSE2 = CeresConstraintSE2;
 
@@ -74,9 +74,9 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_OBJECTIVE_AUTODIFF)
 
 TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
 {
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SE2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SE2d>();
 
   // 0 + pi
 
@@ -84,7 +84,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   double delta[SE2Tangentd::RepSize] = {1.0, 1.0, MANIF_PI};
   double x_plus_delta[SE2d::RepSize] = {0.0, 0.0, 0.0, 0.0};
 
-  auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
+  auto_diff_manifold->Plus(x, delta, x_plus_delta);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[0]);
@@ -108,7 +108,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   x_plus_delta[2] = 1;
   x_plus_delta[3] = 0;
 
-  auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
+  auto_diff_manifold->Plus(x, delta, x_plus_delta);
 
   /// @todo
 //  EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[0]);
@@ -120,7 +120,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SE2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[SE2d::RepSize*SE2Tangentd::RepSize];
-  auto_diff_local_parameterization->ComputeJacobian(x, J_rplus);
+  auto_diff_manifold->ComputeJacobian(x, J_rplus);
 
   /// @todo values copied from terminal...
   EXPECT_DOUBLE_EQ( 0.70710678118654746, J_rplus[0]);
@@ -142,7 +142,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+  problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
 
   ceres::Problem problem(problem_options);
 
@@ -180,12 +180,12 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_SMALL_PROBLEM_AUTODIFF)
                             nullptr,
                             average_state.data() );
 
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SE2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SE2d>();
 
   problem.SetParameterization( average_state.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -223,7 +223,7 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+  problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
 
   //
   //    5 ____ 4
@@ -318,33 +318,33 @@ TEST(TEST_LOCAL_PARAMETRIZATION, TEST_SE2_CONSTRAINT_AUTODIFF)
                             nullptr,
                             state_0.data() );
 
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SE2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SE2d>();
 
   problem.SetParameterization( state_0.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_1.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_2.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_3.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_4.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_5.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_6.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_7.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/ceres/gtest_so2_ceres.cpp
+++ b/test/ceres/gtest_so2_ceres.cpp
@@ -141,8 +141,8 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
     auto_diff_manifold =
       make_manifold_autodiff<SO2d>();
 
-  problem.SetParameterization( average_state.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( average_state.data(),
+                       auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -259,29 +259,29 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
     auto_diff_manifold =
       make_manifold_autodiff<SO2d>();
 
-  problem.SetParameterization( state_0.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_0.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_1.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_1.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_2.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_2.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_3.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_3.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_4.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_4.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_5.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_5.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_6.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_6.data(),
+                       auto_diff_manifold.get() );
 
-  problem.SetParameterization( state_7.data(),
-                               auto_diff_manifold.get() );
+  problem.SetManifold( state_7.data(),
+                       auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/ceres/gtest_so2_ceres.cpp
+++ b/test/ceres/gtest_so2_ceres.cpp
@@ -50,9 +50,9 @@ TEST(TEST_SO2_CERES, TEST_SO2_OBJECTIVE_AUTODIFF)
 
 TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
 {
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SO2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SO2d>();
 
   // 0 + pi
 
@@ -60,7 +60,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   double delta[1] = {MANIF_PI};
   double x_plus_delta[2] = {0.0, 0.0};
 
-  auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
+  auto_diff_manifold->Plus(x, delta, x_plus_delta);
 
   EXPECT_DOUBLE_EQ(-1.0, x_plus_delta[0]);
   EXPECT_NEAR(0.0, x_plus_delta[1], 1e-15);
@@ -76,7 +76,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   x_plus_delta[0] = 0;
   x_plus_delta[1] = 0;
 
-  auto_diff_local_parameterization->Plus(x, delta, x_plus_delta);
+  auto_diff_manifold->Plus(x, delta, x_plus_delta);
 
   EXPECT_DOUBLE_EQ(cos(-3.*MANIF_PI/4.), x_plus_delta[0]);
   EXPECT_DOUBLE_EQ(sin(-3.*MANIF_PI/4.), x_plus_delta[1]);
@@ -84,7 +84,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SO2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[2];
-  auto_diff_local_parameterization->ComputeJacobian(x, J_rplus);
+  auto_diff_manifold->ComputeJacobian(x, J_rplus);
 
   EXPECT_DOUBLE_EQ(-0.70710678118654746, J_rplus[0]);
   EXPECT_DOUBLE_EQ( 0.70710678118654757, J_rplus[1]);
@@ -95,7 +95,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+  problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
 
   ceres::Problem problem(problem_options);
 
@@ -137,12 +137,12 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
                             nullptr,
                             average_state.data() );
 
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SO2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SO2d>();
 
   problem.SetParameterization( average_state.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -170,7 +170,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
-  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+  problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
 
   ceres::Problem problem(problem_options);
 
@@ -255,33 +255,33 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
                             nullptr,
                             state_0.data() );
 
-  std::shared_ptr<ceres::LocalParameterization>
-    auto_diff_local_parameterization =
-      make_local_parameterization_autodiff<SO2d>();
+  std::shared_ptr<ceres::Manifold>
+    auto_diff_manifold =
+      make_manifold_autodiff<SO2d>();
 
   problem.SetParameterization( state_0.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_1.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_2.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_3.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_4.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_5.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_6.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   problem.SetParameterization( state_7.data(),
-                               auto_diff_local_parameterization.get() );
+                               auto_diff_manifold.get() );
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/ceres/gtest_so2_ceres.cpp
+++ b/test/ceres/gtest_so2_ceres.cpp
@@ -50,9 +50,13 @@ TEST(TEST_SO2_CERES, TEST_SO2_OBJECTIVE_AUTODIFF)
 
 TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
 {
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
-    auto_diff_manifold =
-      make_manifold_autodiff<SO2d>();
+    auto_diff_manifold = make_manifold_autodiff<SO2d>();
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_manifold = make_local_parameterization_autodiff<SO2d>();
+#endif
 
   // 0 + pi
 
@@ -84,7 +88,11 @@ TEST(TEST_SO2_CERES, TEST_SO2_LOCAL_PARAMETRIZATION_AUTODIFF)
   EXPECT_NEAR(-3.*MANIF_PI/4., Eigen::Map<const SO2d>(x_plus_delta).angle(), 1e-15);
 
   double J_rplus[2];
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
+  auto_diff_manifold->PlusJacobian(x, J_rplus);
+#else
   auto_diff_manifold->ComputeJacobian(x, J_rplus);
+#endif
 
   EXPECT_DOUBLE_EQ(-0.70710678118654746, J_rplus[0]);
   EXPECT_DOUBLE_EQ( 0.70710678118654757, J_rplus[1]);
@@ -95,7 +103,11 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#else
+  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#endif
 
   ceres::Problem problem(problem_options);
 
@@ -137,12 +149,21 @@ TEST(TEST_SO2_CERES, TEST_SO2_SMALL_PROBLEM_AUTODIFF)
                             nullptr,
                             average_state.data() );
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
     auto_diff_manifold =
       make_manifold_autodiff<SO2d>();
 
   problem.SetManifold( average_state.data(),
                        auto_diff_manifold.get() );
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_local_parameterization =
+      make_local_parameterization_autodiff<SO2d>();
+
+  problem.SetParameterization( average_state.data(),
+                               auto_diff_local_parameterization.get() );
+#endif
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";
@@ -170,7 +191,11 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
   // Tell ceres not to take ownership of the raw pointers
   ceres::Problem::Options problem_options;
   problem_options.cost_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   problem_options.manifold_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#else
+  problem_options.local_parameterization_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
+#endif
 
   ceres::Problem problem(problem_options);
 
@@ -255,6 +280,7 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
                             nullptr,
                             state_0.data() );
 
+#if CERES_VERSION_MAJOR >= 2 && CERES_VERSION_MINOR >= 2
   std::shared_ptr<ceres::Manifold>
     auto_diff_manifold =
       make_manifold_autodiff<SO2d>();
@@ -282,6 +308,35 @@ TEST(TEST_SO2_CERES, TEST_SO2_CONSTRAINT_AUTODIFF)
 
   problem.SetManifold( state_7.data(),
                        auto_diff_manifold.get() );
+#else
+  std::shared_ptr<ceres::LocalParameterization>
+    auto_diff_local_parameterization =
+      make_local_parameterization_autodiff<SO2d>();
+
+  problem.SetParameterization( state_0.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_1.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_2.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_3.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_4.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_5.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_6.data(),
+                               auto_diff_local_parameterization.get() );
+
+  problem.SetParameterization( state_7.data(),
+                               auto_diff_local_parameterization.get() );
+#endif
 
   std::cout << "-----------------------------\n";
   std::cout << "|       Calling Solve !     |\n";

--- a/test/gtest/CMakeLists.txt.in
+++ b/test/gtest/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.1)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Ceres [v2.2.0](http://ceres-solver.org/version_history.html) has deprecated ceres::LocalParametrization in favor of ceres::Manifold. This PR updates the CeresManifoldFunctor to match the new expected interface for the ceres::Manifold. 

Ubuntu 24.04 seems to require Ceres to be updated to v2.2.0 when building Ceres from source. 

Edit:
Closes https://github.com/artivis/manif/issues/288
Closes https://github.com/artivis/manif/issues/290
Closes https://github.com/artivis/manif/issues/296