### PR TITLE
Add Lie bracket

### DIFF
--- a/include/manif/impl/bracket.h
+++ b/include/manif/impl/bracket.h
@@ -1,0 +1,35 @@
+#ifndef _MANIF_MANIF_IMPL_BRACKET_H_
+#define _MANIF_MANIF_IMPL_BRACKET_H_
+
+namespace manif {
+namespace internal {
+
+template <typename Derived>
+struct BracketEvaluatorImpl {
+  template <typename TL, typename TR>
+  static typename Derived::Tangent run(const TL& a, const TR& b) {
+    return a.smallAdj() * b;
+  }
+};
+
+template <typename Derived, typename DerivedOther>
+struct BracketEvaluator : BracketEvaluatorImpl<Derived> {
+  using Base = BracketEvaluatorImpl<Derived>;
+
+  BracketEvaluator(const Derived& xptr, const DerivedOther& xptr_o)
+  : xptr_(xptr), xptr_o_(xptr_o) {}
+
+  typename Derived::Tangent run() {
+    return Base::run(xptr_, xptr_o_);
+  }
+
+protected:
+
+  const Derived& xptr_;
+  const DerivedOther& xptr_o_;
+};
+
+} // namespace internal
+} // namespace manif
+
+#endif // _MANIF_MANIF_IMPL_BRACKET_H_

--- a/include/manif/impl/rn/RnTangent_base.h
+++ b/include/manif/impl/rn/RnTangent_base.h
@@ -202,6 +202,14 @@ struct RandomEvaluatorImpl<RnTangentBase<Derived>>
   }
 };
 
+template <typename Derived>
+struct BracketEvaluatorImpl<RnTangentBase<Derived>> {
+  template <typename TL, typename TR>
+  static typename Derived::Tangent run(const TL&, const TR&) {
+    return Derived::Tangent::Zero();
+  }
+};
+
 } // namespace internal
 } // namespace manif
 

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -5,6 +5,7 @@
 #include "manif/impl/traits.h"
 #include "manif/impl/generator.h"
 #include "manif/impl/random.h"
+#include "manif/impl/bracket.h"
 #include "manif/impl/eigen.h"
 
 #include "manif/constants.h"
@@ -256,6 +257,16 @@ public:
   Jacobian smallAdj() const;
 
   /**
+   * @brief Compute the Lie bracket [this,b] in vector form.
+   *
+   * @tparam _DerivedOther
+   * @param b Another tangent object of the same group.
+   * @return The Lie bracket [this,b] in vector form.
+   */
+  template <typename _DerivedOther>
+  Tangent bracket(const TangentBase<_DerivedOther>& b) const;
+
+  /**
    * @brief Evaluate whether this and v are 'close'.
    * @details This evaluation is performed element-wise.
    * @param[in] v A vector.
@@ -345,6 +356,19 @@ public:
   static LieAlg Generator(const int i);
   //! Static helper to get a Basis of the Lie group.
   static InnerWeightsMatrix InnerWeights();
+
+  /**
+   * @brief Compute the Lie bracket [a,b] in vector form.
+   *
+   * @tparam _DerivedOther
+   * @param a A Tangent object.
+   * @param b A second Tangent object.
+   * @return @return LieAlg The Lie bracket [a,b] in vector form.
+   */
+  template <typename _DerivedOther>
+  static Tangent Bracket(
+    const TangentBase<_Derived>& a, const TangentBase<_DerivedOther>& b
+  );
 
 protected:
 
@@ -623,6 +647,17 @@ TangentBase<_Derived>::smallAdj() const
 }
 
 template <typename _Derived>
+template <typename _DerivedOther>
+typename TangentBase<_Derived>::Tangent TangentBase<_Derived>::bracket(
+  const TangentBase<_DerivedOther>& b
+) const {
+  return internal::BracketEvaluator<
+    typename internal::traits<_Derived>::Base,
+    typename internal::traits<_DerivedOther>::Base
+  >(derived(), b.derived()).run();
+}
+
+template <typename _Derived>
 template <typename _EigenDerived>
 bool TangentBase<_Derived>::isApprox(
     const Eigen::MatrixBase<_EigenDerived>& t,
@@ -693,6 +728,14 @@ TangentBase<_Derived>::InnerWeights()
 {
   return internal::InnerWeightsEvaluator<
       typename internal::traits<_Derived>::Base>::run();
+}
+
+template <typename _Derived>
+template <typename _DerivedOther>
+typename TangentBase<_Derived>::Tangent TangentBase<_Derived>::Bracket(
+  const TangentBase<_Derived>& a, const TangentBase<_DerivedOther>& b
+) {
+  return a.bracket(b);
 }
 
 // Math

--- a/include/manif/impl/tangent_base.h
+++ b/include/manif/impl/tangent_base.h
@@ -363,7 +363,7 @@ public:
    * @tparam _DerivedOther
    * @param a A Tangent object.
    * @param b A second Tangent object.
-   * @return @return LieAlg The Lie bracket [a,b] in vector form.
+   * @return The Lie bracket [a,b] in vector form.
    */
   template <typename _DerivedOther>
   static Tangent Bracket(


### PR DESCRIPTION
Add the Lie bracket in vector form (` [x,y]^v = adj(x) . y `).

It is implemented as both : 
- ` x.bracket(y) `
- ` Tangent::Bracket(x, y)` 

with the later being a personal favorite in terms of notation.

The actual bracket in the Lie algebra can then be computed as `Tangent::Bracket(x, y).hat()`.

Note: the `vee` operator will be implemented in a subsequent pr.

Closes #267 .