### PR TITLE
Fix link to GTest if GTest is found via find_package

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,8 +34,7 @@ endif()
 # small helper function
 function(manif_add_gtest target)
   add_executable(${target} ${ARGN})
-  add_dependencies(${target} gtest)
-  target_link_libraries(${target} ${PROJECT_NAME} gtest)
+  target_link_libraries(${target} ${PROJECT_NAME} GTest::gtest)
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # GCC is not strict enough by default, so enable most of the warnings.


### PR DESCRIPTION
Thanks @artivis for the new tag! I was updating the release in conda-forge, and I took the occasion to re-enable the tests there on Windows. 

I noticed that the 0.0.5 for us build was failing with an error related to gtest:
~~~
CMake Error at test/CMakeLists.txt:37 (add_dependencies):
  The dependency target "gtest" of target "gtest_misc" does not exist.
Call Stack (most recent call first):
  test/CMakeLists.txt:53 (manif_add_gtest)


CMake Error at test/CMakeLists.txt:37 (add_dependencies):
  The dependency target "gtest" of target "gtest_rn" does not exist.
Call Stack (most recent call first):
  test/rn/CMakeLists.txt:3 (manif_add_gtest)
~~~

So I took the occasion to cleanup the linking to gtest. I used `GTest::gtest` as imported target to link against, and remove the `add_dependencies` step as it is implicit in `target_link_libraries`.
