### PR TITLE
Add missing #include <cassert> to macro.h

### DIFF
--- a/include/manif/impl/macro.h
+++ b/include/manif/impl/macro.h
@@ -1,6 +1,7 @@
 #ifndef _MANIF_MANIF_FWD_H_
 #define _MANIF_MANIF_FWD_H_
 
+#include <cassert>
 #include <stdexcept> // for std::runtime_error
 #include <utility> // for std::forward
 


### PR DESCRIPTION
Needed by `MANIF_ASSERT()`. Eigen 5.0.0 no longer includes `<cassert>`, which the code happened to rely on.