### PR TITLE
CMake fixes for Eigen3 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # Note that eigen 3.2 (on Ubuntu Wily) only provides EIGEN3_INCLUDE_DIR,
 # not EIGEN3_INCLUDE_DIRS, so we have to set the latter from the former.
-if(NOT EIGEN3_INCLUDE_DIRS)
+if(NOT EIGEN3_INCLUDE_DIRS AND (DEFINED EIGEN3_INCLUDE_DIR))
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif()
 
@@ -43,12 +43,16 @@ if((NOT (DEFINED EIGEN3_VERSION)) AND (DEFINED EIGEN3_VERSION_STRING))
   set(EIGEN3_VERSION ${EIGEN3_VERSION_STRING})
 endif()
 
-if(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
-  message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS},"
-                  "but this version has a [bug](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1643)")
-elseif(${EIGEN3_VERSION} VERSION_LESS "3.3.8")
-  message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS}. "
-                  "Beware that the move semantic has a bug and resolves to a simple copy.")
+# Eigen3 >= 5.0.0 doe not define EIGEN3_VERSION_STRING or EIGEN3_VERSION, but if that is
+# is the case we are sure that Eigen is not ==3.3.6 or <=3.3.8
+if(DEFINED EIGEN3_VERSION)
+  if(${EIGEN3_VERSION} VERSION_EQUAL "3.3.6")
+    message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS},"
+                    "but this version has a [bug](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1643)")
+  elseif(${EIGEN3_VERSION} VERSION_LESS "3.3.8")
+    message(WARNING "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIRS}. "
+                    "Beware that the move semantic has a bug and resolves to a simple copy.")
+  endif()
 endif()
 
 # Options. Turn on with 'cmake -DBUILD_TESTING=ON'.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # fall-back to the version provided in the cmake/modules.
 find_package(Eigen3 QUIET)
 
-if(NOT EIGEN3_FOUND)
+if(NOT Eigen3_FOUND)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
   find_package(Eigen3 REQUIRED)
 endif()


### PR DESCRIPTION
Hello @artivis, I hope everything is fine!

Eigen3 5.0.0 was recently released, and this PR fixes the CMake logic of manif to permit to use it out of the box, with the following modifications:
* The current logic of "trying to find Eigen with a CMake Config and then fallback to the built-in FindEigen3.cmake module" was actually broken, as it checked for `EIGEN3_FOUND` variable instead of the `Eigen3_FOUND` variable actually set by `find_package(Eigen3 QUIET)` . However, this was never a problem as the built-in module worked fine for Eigen3 versions <= 3.4.0. However, now the built-in `FindEigen3.cmake` does not work anymore fine for Eigen3 >= 5.0.0, so avoiding that is invoked if not necessary is important. 
* Eigen3 5.0.0 does not define anymore `EIGEN3_VERSION_STRING` and `EIGEN3_INCLUDE_DIRS` CMake variables, see https://github.com/eigen-mirror/eigen/blob/5.0.0/cmake/Eigen3Config.cmake.in vs https://github.com/eigen-mirror/eigen/blob/3.4.1/cmake/Eigen3Config.cmake.in . Fortunately, such variables were just used to check if the Eigen3 version was either ==3.3.6 or <=3.3.8, and those are checks we can avoid if we know that Eigen3>=5.0.0

As a related note, I think all non-EOL distributions of Eigen actually ship a well formed  `Eigen3Config.cmake` file, so it could make sense to drop the internal `FindEigen3.cmake`, but that is not strictly related to this PR.


xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47